### PR TITLE
UIOA-25 upgrade react-intl-safe-html

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Change history for ui-oa
 
 ## 1.0.0 (In Progress)
-* TODO
 
+* Upgrade `@folio/react-intl-safe-html` for compatibility with `@folio/stripes` `v7`. UIOA-25

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "sinon": "^9.0.2"
   },
   "dependencies": {
-    "@folio/react-intl-safe-html": "^2.0.0",
+    "@folio/react-intl-safe-html": "^3.1.0",
     "@k-int/stripes-kint-components": "^1.1.1",
     "@folio/stripes-erm-components": "^6.0.0",
     "classnames": "^2.2.6",


### PR DESCRIPTION
Upgrade `@folio/react-intl-safe-html` for compatibility with
`@folio/stripes` `v7` (react 17, react-intl 5).

@SamHepburnKI, @EthanFreestone: I don't have write privs in this repo to add PR reviewers. If this looks good to you, please merge it. Thanks!

Refs [UIOA-25](https://issues.folio.org/browse/UIOA-25), [STRIPES-769](https://issues.folio.org/browse/STRIPES-769)