### PR TITLE
fix: Formatted 'Status Date' field

### DIFF
--- a/src/components/PublicationRequestSections/PublicationStatus/PublicationStatus.js
+++ b/src/components/PublicationRequestSections/PublicationStatus/PublicationStatus.js
@@ -7,7 +7,8 @@ import {
   Accordion,
   Badge,
   MultiColumnList,
-  Row
+  Row,
+  FormattedUTCDate
 } from '@folio/stripes/components';
 
 const propTypes = {
@@ -17,6 +18,9 @@ const propTypes = {
 const formatter = {
   publicationStatus: e => {
     return e?.publicationStatus?.label;
+  },
+  statusDate: e => {
+    return <FormattedUTCDate value={e?.statusDate} />;
   },
 };
 


### PR DESCRIPTION
Status date now displays YYY-MM-DD instead of YYY-MM-DDT00:00Z

UI-OA 48