### PR TITLE
fix: Custom Properties Conditional

### DIFF
--- a/src/components/PublicationRequestSections/Agreement/Agreement.js
+++ b/src/components/PublicationRequestSections/Agreement/Agreement.js
@@ -129,7 +129,7 @@ const Agreement = ({ request }) => {
           >
             {renderAgreement(request?.agreement?.remoteId_object)}
           </Card>
-          {renderCustomProperties()}
+          {customProperties && renderCustomProperties()}
         </>
       ) : (
         renderEmpty()


### PR DESCRIPTION
Custom props no longer rendered when agreement contains no custom props