### PR TITLE
feat: Invoice tweaks

### DIFF
--- a/src/components/InvoiceFormSections/InvoiceLineTypedownForm/InvoiceLineTypedownForm.js
+++ b/src/components/InvoiceFormSections/InvoiceLineTypedownForm/InvoiceLineTypedownForm.js
@@ -9,7 +9,10 @@ import { Button, Layout, IconButton, Card } from '@folio/stripes/components';
 import { AppIcon } from '@folio/stripes/core';
 import { requiredValidator } from '@folio/stripes-erm-components';
 
-import { QueryTypedown, typedownQueryKey } from '@k-int/stripes-kint-components';
+import {
+  QueryTypedown,
+  typedownQueryKey,
+} from '@k-int/stripes-kint-components';
 
 import { InvoiceLineInfo } from '../../InvoiceSections';
 import { InvoiceLineModal } from '../../Modals';
@@ -48,7 +51,11 @@ const InvoiceLineTypedownForm = ({ charge }) => {
       <Layout className="textCentered">
         <Button
           buttonStyle="primary"
-          disabled={values?.selectedInvoice?.status === 'Approved'}
+          disabled={
+            values?.selectedInvoice?.status === 'Approved' ||
+            values?.selectedInvoice?.status === 'Paid' ||
+            values?.selectedInvoice?.status === 'Cancelled'
+          }
           marginBottom0
           onClick={() => setShowInvoiceLineModal(true)}
         >
@@ -75,7 +82,7 @@ const InvoiceLineTypedownForm = ({ charge }) => {
     <>
       <Field
         component={QueryTypedown}
-        dataFormatter={data => data?.invoiceLines}
+        dataFormatter={(data) => data?.invoiceLines}
         label={
           <FormattedMessage id="ui-oa.charge.invoiceLine.addInvoiceLine" />
         }

--- a/src/components/InvoiceFormSections/InvoiceLineTypedownForm/InvoiceLineTypedownForm.js
+++ b/src/components/InvoiceFormSections/InvoiceLineTypedownForm/InvoiceLineTypedownForm.js
@@ -5,7 +5,13 @@ import { Field, useForm, useFormState } from 'react-final-form';
 
 import { useQueryClient } from 'react-query';
 
-import { Button, Layout, IconButton, Card } from '@folio/stripes/components';
+import {
+  Button,
+  Layout,
+  IconButton,
+  Card,
+  MessageBanner,
+} from '@folio/stripes/components';
 import { AppIcon } from '@folio/stripes/core';
 import { requiredValidator } from '@folio/stripes-erm-components';
 
@@ -28,6 +34,9 @@ const InvoiceLineTypedownForm = ({ charge }) => {
 
   const invoiceLinesPath = 'invoice/invoice-lines';
   const queryClient = useQueryClient();
+  const canCreate = ['Paid', 'Approved', 'Cancelled'].every((value) => {
+    return value !== values?.selectedInvoice?.status;
+  });
 
   const handleInvoiceLineChange = (invoiceLine) => {
     change('invoiceLine', invoiceLine);
@@ -51,11 +60,7 @@ const InvoiceLineTypedownForm = ({ charge }) => {
       <Layout className="textCentered">
         <Button
           buttonStyle="primary"
-          disabled={
-            values?.selectedInvoice?.status === 'Approved' ||
-            values?.selectedInvoice?.status === 'Paid' ||
-            values?.selectedInvoice?.status === 'Cancelled'
-          }
+          disabled={!canCreate}
           marginBottom0
           onClick={() => setShowInvoiceLineModal(true)}
         >
@@ -94,6 +99,11 @@ const InvoiceLineTypedownForm = ({ charge }) => {
         required
         validate={requiredValidator}
       />
+      {(!canCreate && !values?.invoiceLine) && (
+        <MessageBanner type="warning">
+          <FormattedMessage id="ui-oa.charge.invoiceLine.noNewInvoiceLine" />
+        </MessageBanner>
+      )}
       {values?.invoiceLine && (
         <Card
           cardStyle="positive"

--- a/src/components/InvoiceFormSections/InvoiceLineTypedownForm/InvoiceLineTypedownForm.js
+++ b/src/components/InvoiceFormSections/InvoiceLineTypedownForm/InvoiceLineTypedownForm.js
@@ -48,6 +48,7 @@ const InvoiceLineTypedownForm = ({ charge }) => {
       <Layout className="textCentered">
         <Button
           buttonStyle="primary"
+          disabled={values?.selectedInvoice?.status === 'Approved'}
           marginBottom0
           onClick={() => setShowInvoiceLineModal(true)}
         >

--- a/translations/ui-oa/en.json
+++ b/translations/ui-oa/en.json
@@ -240,6 +240,7 @@
   "charge.invoice.unlink": "Unlink",
 
   "charge.invoice.addInvoice": "Add invoice",
+  "charge.invoiceLine.noNewInvoiceLine": "You cannot generate new invoice lines for invoices which are approved, cancelled or paid",
   "charge.invoiceLine.addInvoiceLine": "Add invoice line",
   "charge.invoiceLine.newInvoiceLine": "New invoice line",
   "charge.invoice.useCurrentExchange": "Use current exchange rate",


### PR DESCRIPTION
Invoice line generation is now disabled for invoices which have the status of Approved, Paid or cancelled, a warning banner is also now displayed to reflect this