### PR TITLE
fix: Empty field parsing

### DIFF
--- a/src/components/ChargeFormSections/ChargeInfoForm/ChargeInfoForm.js
+++ b/src/components/ChargeFormSections/ChargeInfoForm/ChargeInfoForm.js
@@ -147,6 +147,7 @@ const ChargeInfoForm = () => {
             component={TextField}
             label={<FormattedMessage id="ui-oa.charge.discount" />}
             name="discount"
+            parse={v => Number(v)}
             type="number"
             validate={composeValidators(validateNotNegative, validateAsDecimal)}
           />
@@ -191,6 +192,7 @@ const ChargeInfoForm = () => {
             component={TextArea}
             label={<FormattedMessage id="ui-oa.charge.discountNote" />}
             name="discountNote"
+            parse={v => v}
           />
         </Col>
       </Row>
@@ -246,6 +248,7 @@ const ChargeInfoForm = () => {
             component={TextArea}
             label={<FormattedMessage id="ui-oa.charge.payerNote" />}
             name="payerNote"
+            parse={v => v}
           />
         </Col>
       </Row>
@@ -256,6 +259,7 @@ const ChargeInfoForm = () => {
             fullWidth
             label={<FormattedMessage id="ui-oa.charge.description" />}
             name="description"
+            parse={v => v}
           />
         </Col>
       </Row>

--- a/src/components/ChargeSections/ChargeInfo/ChargeInfo.js
+++ b/src/components/ChargeSections/ChargeInfo/ChargeInfo.js
@@ -94,7 +94,7 @@ const ChargeInfo = ({ request, charge }) => {
         <Col xs={3}>
           <KeyValue
             label={<FormattedMessage id="ui-oa.charge.tax" />}
-            value={charge?.tax ? charge?.tax + '%' : null}
+            value={charge?.tax + '%'}
           />
         </Col>
       </Row>

--- a/src/components/CorrespondenceFormSections/CorrespondenceInfoForm/CorrespondenceInfoForm.js
+++ b/src/components/CorrespondenceFormSections/CorrespondenceInfoForm/CorrespondenceInfoForm.js
@@ -26,7 +26,10 @@ const CorrespondenceInfoForm = () => {
     CORRESPONDENCE_MODE,
   ]);
 
-  const categoryValues = selectifyRefdata(refdataValues, CORRESPONDENCE_CATEGORY);
+  const categoryValues = selectifyRefdata(
+    refdataValues,
+    CORRESPONDENCE_CATEGORY
+  );
   const statusValues = selectifyRefdata(refdataValues, CORRESPONDENCE_STATUS);
   const modeValues = selectifyRefdata(refdataValues, CORRESPONDENCE_MODE);
 
@@ -59,8 +62,7 @@ const CorrespondenceInfoForm = () => {
         <Col xs={3}>
           <Field
             component={Select}
-            dataOptions={[
-              { value: '', label: '' }, ...statusValues]}
+            dataOptions={[{ value: '', label: '' }, ...statusValues]}
             id="correspondence-status"
             label={<FormattedMessage id="ui-oa.correspondence.status" />}
             name="status.id"
@@ -71,10 +73,7 @@ const CorrespondenceInfoForm = () => {
         <Col xs={3}>
           <Field
             component={Select}
-            dataOptions={[
-              { value: '', label: '' },
-              ...modeValues
-            ]}
+            dataOptions={[{ value: '', label: '' }, ...modeValues]}
             id="correspondence-mode"
             label={<FormattedMessage id="ui-oa.correspondence.mode" />}
             name="mode.id"
@@ -87,13 +86,11 @@ const CorrespondenceInfoForm = () => {
         <Col xs={3}>
           <Field
             component={Select}
-            dataOptions={[
-              { value: '', label: '' },
-              ...categoryValues
-            ]}
+            dataOptions={[{ value: '', label: '' }, ...categoryValues]}
             id="correspondence-category"
             label={<FormattedMessage id="ui-oa.correspondence.category" />}
             name="category.id"
+            parse={v => v}
           />
         </Col>
       </Row>

--- a/src/components/PartyFormSections/OtherEmailsFieldArray/OtherEmailsFieldArray.js
+++ b/src/components/PartyFormSections/OtherEmailsFieldArray/OtherEmailsFieldArray.js
@@ -28,6 +28,9 @@ const OtherEmailsField = ({ fields: { name } }) => {
             <Col xs={9}>
               <Field
                 component={TextField}
+                label={
+                  <FormattedMessage id="ui-oa.party.emailAddress" />
+                }
                 name={`${name}[${index}].email`}
                 required
                 validate={requiredValidator}

--- a/src/components/PartyFormSections/PartyInfoForm/PartyInfoForm.js
+++ b/src/components/PartyFormSections/PartyInfoForm/PartyInfoForm.js
@@ -35,6 +35,7 @@ const PartyInfoForm = () => {
             id="party-title"
             label={<FormattedMessage id="ui-oa.party.title" />}
             name="title"
+            parse={(v) => v}
           />
         </Col>
         <Col xs={3}>
@@ -60,6 +61,7 @@ const PartyInfoForm = () => {
             component={TextField}
             label={<FormattedMessage id="ui-oa.party.orcidId" />}
             name="orcidId"
+            parse={(v) => v}
           />
         </Col>
       </Row>
@@ -69,6 +71,7 @@ const PartyInfoForm = () => {
             component={TextField}
             label={<FormattedMessage id="ui-oa.party.mainEmailAddress" />}
             name="mainEmail"
+            parse={(v) => v}
           />
         </Col>
         <Col xs={3}>
@@ -76,6 +79,7 @@ const PartyInfoForm = () => {
             component={TextField}
             label={<FormattedMessage id="ui-oa.party.phone" />}
             name="phone"
+            parse={(v) => v}
           />
         </Col>
         <Col xs={3}>
@@ -83,6 +87,7 @@ const PartyInfoForm = () => {
             component={TextField}
             label={<FormattedMessage id="ui-oa.party.mobilePhone" />}
             name="mobile"
+            parse={(v) => v}
           />
         </Col>
       </Row>

--- a/src/components/PartyFormSections/StreetAddress/StreetAddress.js
+++ b/src/components/PartyFormSections/StreetAddress/StreetAddress.js
@@ -26,6 +26,7 @@ const StreetAddress = () => {
               component={TextField}
               label={<FormattedMessage id="ui-oa.party.streetAddress.name" />}
               name="streetAddress.address.name"
+              parse={(v) => v}
             />
           </Col>
           <Col xs={3}>
@@ -35,6 +36,7 @@ const StreetAddress = () => {
                 <FormattedMessage id="ui-oa.party.streetAddress.addressLineOne" />
               }
               name="streetAddress.address.addressLineOne"
+              parse={(v) => v}
             />
           </Col>
           <Col xs={3}>
@@ -44,6 +46,7 @@ const StreetAddress = () => {
                 <FormattedMessage id="ui-oa.party.streetAddress.addressLineTwo" />
               }
               name="streetAddress.address.addressLineTwo"
+              parse={(v) => v}
             />
           </Col>
           <Col xs={3}>
@@ -51,6 +54,7 @@ const StreetAddress = () => {
               component={TextField}
               label={<FormattedMessage id="ui-oa.party.streetAddress.city" />}
               name="streetAddress.address.city"
+              parse={(v) => v}
             />
           </Col>
         </Row>
@@ -60,6 +64,7 @@ const StreetAddress = () => {
               component={TextField}
               label={<FormattedMessage id="ui-oa.party.streetAddress.region" />}
               name="streetAddress.address.region"
+              parse={(v) => v}
             />
           </Col>
           <Col xs={3}>

--- a/src/components/PublicationRequestFormSections/PublicationForm/PublicationForm/PublicationForm.js
+++ b/src/components/PublicationRequestFormSections/PublicationForm/PublicationForm/PublicationForm.js
@@ -18,12 +18,7 @@ import selectifyRefdata from '../../../../util/selectifyRefdata';
 import PublicationJournal from '../PublicationJournal';
 import PublicationBook from '../PublicationBook';
 
-const [
-  PUBLICATION_TYPE,
-  PUBLISHER,
-  SUBTYPE,
-  LICENSE,
- ] = [
+const [PUBLICATION_TYPE, PUBLISHER, SUBTYPE, LICENSE] = [
   'PublicationRequest.PublicationType',
   'PublicationRequest.Publisher',
   'PublicationRequest.Subtype',
@@ -37,19 +32,24 @@ const PublicationForm = () => {
     PUBLICATION_TYPE,
     PUBLISHER,
     SUBTYPE,
-    LICENSE
-   ]);
+    LICENSE,
+  ]);
 
-  const publicationTypeValues = selectifyRefdata(refdataValues, PUBLICATION_TYPE);
+  const publicationTypeValues = selectifyRefdata(
+    refdataValues,
+    PUBLICATION_TYPE
+  );
   const publisherValues = selectifyRefdata(refdataValues, PUBLISHER);
   const subtypeValues = selectifyRefdata(refdataValues, SUBTYPE);
   const licenseValues = selectifyRefdata(refdataValues, LICENSE);
 
   const getRDVId = (desc, value) => {
     // First filter by desc
-    const refdataDescValues = refdataValues?.find(rdc => rdc.desc === desc);
+    const refdataDescValues = refdataValues?.find((rdc) => rdc.desc === desc);
     // Then grab the values and filter by value
-    const refdataValue = refdataDescValues?.values?.find(rdv => rdv.value === value);
+    const refdataValue = refdataDescValues?.values?.find(
+      (rdv) => rdv.value === value
+    );
     // At this point we have the refdataValue object, which is an id, a value and a label (or undefined).
     // Return the id
     return refdataValue?.id;
@@ -68,6 +68,7 @@ const PublicationForm = () => {
             component={TextField}
             label={<FormattedMessage id="ui-oa.publicationRequest.doi" />}
             name="doi"
+            parse={(v) => v}
           />
         </Col>
         <Col xs={9} />
@@ -78,8 +79,11 @@ const PublicationForm = () => {
           <Field
             component={Select}
             dataOptions={[{ value: '', label: '' }, ...publicationTypeValues]}
-            label={<FormattedMessage id="ui-oa.publicationRequest.publicationType" />}
+            label={
+              <FormattedMessage id="ui-oa.publicationRequest.publicationType" />
+            }
             name="publicationType.id"
+            parse={(v) => v}
           />
         </Col>
         <Col xs={3}>
@@ -88,6 +92,7 @@ const PublicationForm = () => {
             dataOptions={[{ value: '', label: '' }, ...subtypeValues]}
             label={<FormattedMessage id="ui-oa.publicationRequest.subtype" />}
             name="subtype.id"
+            parse={(v) => v}
           />
         </Col>
         <Col xs={3}>
@@ -96,6 +101,7 @@ const PublicationForm = () => {
             dataOptions={[{ value: '', label: '' }, ...publisherValues]}
             label={<FormattedMessage id="ui-oa.publicationRequest.publisher" />}
             name="publisher.id"
+            parse={(v) => v}
           />
         </Col>
         <Col xs={3}>
@@ -104,6 +110,7 @@ const PublicationForm = () => {
             dataOptions={[{ value: '', label: '' }, ...licenseValues]}
             label={<FormattedMessage id="ui-oa.publicationRequest.license" />}
             name="license.id"
+            parse={(v) => v}
           />
         </Col>
       </Row>
@@ -112,15 +119,21 @@ const PublicationForm = () => {
         <Col xs={6}>
           <Field
             component={TextArea}
-            label={<FormattedMessage id="ui-oa.publicationRequest.publicationTitle" />}
+            label={
+              <FormattedMessage id="ui-oa.publicationRequest.publicationTitle" />
+            }
             name="publicationTitle"
+            parse={(v) => v}
           />
         </Col>
         <Col xs={6}>
           <Field
             component={TextArea}
-            label={<FormattedMessage id="ui-oa.publicationRequest.authorNames" />}
+            label={
+              <FormattedMessage id="ui-oa.publicationRequest.authorNames" />
+            }
             name="authorNames"
+            parse={(v) => v}
           />
         </Col>
       </Row>
@@ -129,15 +142,21 @@ const PublicationForm = () => {
         <Col xs={6}>
           <Field
             component={TextField}
-            label={<FormattedMessage id="ui-oa.publicationRequest.publicationUrl" />}
+            label={
+              <FormattedMessage id="ui-oa.publicationRequest.publicationUrl" />
+            }
             name="publicationUrl"
+            parse={(v) => v}
           />
         </Col>
         <Col xs={6}>
           <Field
             component={TextField}
-            label={<FormattedMessage id="ui-oa.publicationRequest.localReference" />}
+            label={
+              <FormattedMessage id="ui-oa.publicationRequest.localReference" />
+            }
             name="localReference"
+            parse={(v) => v}
           />
         </Col>
       </Row>
@@ -156,14 +175,11 @@ const PublicationForm = () => {
         </Col>
       </Row>
 
-      {values.publicationType?.id === journalArticleId &&
+      {values.publicationType?.id === journalArticleId && (
         <PublicationJournal />
-      }
+      )}
 
-      {values.publicationType?.id === bookId &&
-        <PublicationBook />
-      }
-
+      {values.publicationType?.id === bookId && <PublicationBook />}
     </Accordion>
   );
 };

--- a/src/routes/CorrespondenceEditRoute/CorrespondenceEditRoute.js
+++ b/src/routes/CorrespondenceEditRoute/CorrespondenceEditRoute.js
@@ -28,7 +28,13 @@ const CorrespondenceEditRoute = () => {
       })
   );
   const submitCorrespondence = (values) => {
-    putCorrespondence(values);
+    const { category, ...submitValues } = { ...values };
+    if (category?.id) {
+      submitValues.category = category;
+    } else {
+      submitValues.category = null;
+    }
+    putCorrespondence(submitValues);
   };
 
   return (

--- a/src/util/publicationRequestSubmitHandler.js
+++ b/src/util/publicationRequestSubmitHandler.js
@@ -1,6 +1,10 @@
 const publicationRequestSubmitHandler = (values) => {
   const {
     agreement,
+    publicationType,
+    license,
+    publisher,
+    subtype,
     useCorrespondingAuthor: _useCorrespondingAuthor,
     correspondingAuthor,
     requestContact,
@@ -9,6 +13,7 @@ const publicationRequestSubmitHandler = (values) => {
   } = { ...values };
 
   // Explicitly set RequestParty values to null if no partyOwner, to allow unsetting of values
+  // Due to the amount of fields in publication request, this may need refactoring
   if (requestContact?.partyOwner?.id) {
     requestContact.role = 'request_contact';
     submitValues.requestContact = requestContact;
@@ -29,13 +34,37 @@ const publicationRequestSubmitHandler = (values) => {
     submitValues.agreement = null;
   }
 
+  if (publicationType?.id) {
+    submitValues.publicationType = publicationType;
+  } else {
+    submitValues.publicationType = null;
+  }
+
+  if (license?.id) {
+    submitValues.license = license;
+  } else {
+    submitValues.license = null;
+  }
+
+  if (publisher?.id) {
+    submitValues.publisher = publisher;
+  } else {
+    submitValues.publisher = null;
+  }
+
+  if (subtype?.id) {
+    submitValues.subtype = subtype;
+  } else {
+    submitValues.subtype = null;
+  }
+
   if (work) {
     submitValues.work = {
-      id: work.id
+      id: work.id,
     };
   } else {
     submitValues.work = {
-      id: null
+      id: null,
     };
   }
 

--- a/src/util/publicationRequestSubmitHandler.js
+++ b/src/util/publicationRequestSubmitHandler.js
@@ -35,7 +35,7 @@ const publicationRequestSubmitHandler = (values) => {
     };
   } else {
     submitValues.work = {
-      id: ''
+      id: null
     };
   }
 

--- a/translations/ui-oa/en.json
+++ b/translations/ui-oa/en.json
@@ -41,6 +41,7 @@
   "party.givenNames": "Given name(s)",
   "party.orcidId": "ORCID iD",
   "party.mainEmailAddress": "Main email address",
+  "party.emailAddress": "Email address",
   "party.phone": "Phone",
   "party.mobilePhone": "Mobile phone",
   "party.noResultsFound": "No results found",


### PR DESCRIPTION
Fixed issue in which fields would not be saved if empty upon submission whilst editing, this has been fixed in correspondence, charges, publication requests and party edit forms.

Note: publicationSubmitHandler may require some refactoring due to the amount of select fields within the publication request edit form. Also need a decision on whether the field arrays fields should be required, is there a scenario in which users would be submitting the field arrays with empty fields and not simply deleting excess fields.