### PR TITLE
feat: Charge MCL tweaks

### DIFF
--- a/src/components/PublicationRequestSections/Charges/Charges.js
+++ b/src/components/PublicationRequestSections/Charges/Charges.js
@@ -72,30 +72,31 @@ const Charges = ({ request }) => {
   };
 
   const renderInvoiceLineLink = (charge) => {
-    return charge?.invoiceLineItemReference ? (
-      <Tooltip
-        text={
-          <FormattedMessage
-            id="ui-oa.charge.linkToInvoiceLineIndex"
-            values={{ index: charge.rowIndex + 1 }}
-          />
+    return charge?.invoiceLineItemReference &&
+      charge?.chargeStatus?.value === 'invoiced' ? (
+        <Tooltip
+          text={
+            <FormattedMessage
+              id="ui-oa.charge.linkToInvoiceLineIndex"
+              values={{ index: charge.rowIndex + 1 }}
+            />
         }
-      >
-        {({ ref, ariaIds }) => (
-          <a
-            ref={ref}
-            aria-describedby={ariaIds.sub}
-            aria-labelledby={ariaIds.text}
-            href={urls.invoiceLine(
+        >
+          {({ ref, ariaIds }) => (
+            <a
+              ref={ref}
+              aria-describedby={ariaIds.sub}
+              aria-labelledby={ariaIds.text}
+              href={urls.invoiceLine(
               charge?.invoiceReference,
               charge?.invoiceLineItemReference
             )}
-            onClick={(e) => e.stopPropagation()}
-          >
-            {charge?.chargeStatus?.label}
-          </a>
+              onClick={(e) => e.stopPropagation()}
+            >
+              {charge?.chargeStatus?.label}
+            </a>
         )}
-      </Tooltip>
+        </Tooltip>
     ) : (
       charge?.chargeStatus?.label
     );

--- a/src/components/PublicationRequestSections/Charges/Charges.js
+++ b/src/components/PublicationRequestSections/Charges/Charges.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import { FormattedMessage } from 'react-intl';
+import { FormattedMessage, FormattedNumber } from 'react-intl';
 import { useHistory } from 'react-router-dom';
 
 import { IfPermission, useStripes } from '@folio/stripes/core';
@@ -112,7 +112,14 @@ const Charges = ({ request }) => {
       );
     },
     amount: (e) => {
-      return e?.amount?.value + ' ' + e?.amount?.baseCurrency;
+      return (
+        <FormattedNumber
+          currency={e?.amount?.baseCurrency}
+          // eslint-disable-next-line react/style-prop-object
+          style="currency"
+          value={e?.amount?.value}
+        />
+      );
     },
     discount: (e) => {
       return e?.discountType?.value === 'percentage'

--- a/src/components/PublicationRequestSections/Charges/Charges.js
+++ b/src/components/PublicationRequestSections/Charges/Charges.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/style-prop-object */
 import PropTypes from 'prop-types';
 import { FormattedMessage, FormattedNumber } from 'react-intl';
 import { useHistory } from 'react-router-dom';
@@ -87,27 +88,21 @@ const Charges = ({ request }) => {
       return (
         <div>
           <div>
-            <strong>
-              <FormattedMessage
-                id="ui-oa.charge.estimatedPriceLocal"
-                values={{ localCurrency: e?.estimatedPrice?.baseCurrency }}
-              />
-              :{' '}
-            </strong>
-            {e?.estimatedPrice?.value}
+            <FormattedNumber
+              currency={e?.estimatedPrice?.baseCurrency}
+              style="currency"
+              value={e?.estimatedPrice?.value}
+            />
           </div>
-          <div>
-            <strong>
-              <FormattedMessage
-                id="ui-oa.charge.estimatedPriceSpecified"
-                values={{
-                  specifiedCurrency: e?.estimatedInvoicePrice?.baseCurrency,
-                }}
+          {e?.exchangeRate?.toCurrency !== e?.exchangeRate?.fromCurrency && (
+            <div>
+              <FormattedNumber
+                currency={e?.estimatedInvoicePrice?.baseCurrency}
+                style="currency"
+                value={e?.estimatedInvoicePrice?.value}
               />
-              :{' '}
-            </strong>
-            {e?.estimatedInvoicePrice?.value}
-          </div>
+            </div>
+          )}
         </div>
       );
     },
@@ -115,16 +110,21 @@ const Charges = ({ request }) => {
       return (
         <FormattedNumber
           currency={e?.amount?.baseCurrency}
-          // eslint-disable-next-line react/style-prop-object
           style="currency"
           value={e?.amount?.value}
         />
       );
     },
     discount: (e) => {
-      return e?.discountType?.value === 'percentage'
-        ? e?.discount + '%'
-        : e?.discount + ' ' + e?.amount?.baseCurrency;
+      return e?.discountType?.value === 'percentage' ? (
+        e?.discount + '%'
+      ) : (
+        <FormattedNumber
+          currency={e?.amount?.baseCurrency}
+          style="currency"
+          value={e?.discount}
+        />
+      );
     },
     tax: (e) => {
       return e?.tax + '%';
@@ -148,7 +148,7 @@ const Charges = ({ request }) => {
                 discount: <FormattedMessage id="ui-oa.charge.discount" />,
                 tax: <FormattedMessage id="ui-oa.charge.tax" />,
                 estimatedPrices: (
-                  <FormattedMessage id="ui-oa.charge.estimatedPrices" />
+                  <FormattedMessage id="ui-oa.charge.estimatedAmount" />
                 ),
               }}
               columnWidths={{ description: 300 }}

--- a/src/components/PublicationRequestSections/Charges/Charges.js
+++ b/src/components/PublicationRequestSections/Charges/Charges.js
@@ -113,7 +113,7 @@ const Charges = ({ request }) => {
               value={e?.estimatedPrice?.value}
             />
           </div>
-          {e?.exchangeRate?.toCurrency !== e?.exchangeRate?.fromCurrency && (
+          {e?.estimatedInvoicePrice?.baseCurrency !== stripes?.currency && (
             <div>
               <FormattedNumber
                 currency={e?.estimatedInvoicePrice?.baseCurrency}

--- a/src/components/PublicationRequestSections/Charges/Charges.js
+++ b/src/components/PublicationRequestSections/Charges/Charges.js
@@ -1,5 +1,6 @@
 /* eslint-disable react/style-prop-object */
 import PropTypes from 'prop-types';
+import { useState } from 'react';
 import { FormattedMessage, FormattedNumber } from 'react-intl';
 import { useHistory } from 'react-router-dom';
 
@@ -16,6 +17,7 @@ import {
 } from '@folio/stripes/components';
 
 import urls from '../../../util/urls';
+import getSortedItems from '../../../util/getSortedItems';
 
 const propTypes = {
   request: PropTypes.object,
@@ -24,6 +26,23 @@ const propTypes = {
 const Charges = ({ request }) => {
   const stripes = useStripes();
   const history = useHistory();
+
+  const [sortedColumn, setSortedColumn] = useState({
+    column: 'description',
+    direction: 'desc',
+  });
+
+  const sortFormatter = {
+    requestStatus: ['chargeStatus.value', 'category.value', 'payer.value'],
+    amount: ['amount.value'],
+    estimatedPrices: ['estimatedPrice.value', 'estimatedInvoicePrice.value'],
+  };
+
+  const sortedCharges = getSortedItems(
+    request?.charges,
+    sortFormatter,
+    sortedColumn
+  );
 
   const renderBadge = (charges) => {
     return charges ? <Badge>{charges?.length}</Badge> : <Badge>0</Badge>;
@@ -131,6 +150,20 @@ const Charges = ({ request }) => {
     },
   };
 
+  const onHeaderClick = (e, meta) => {
+    if (sortedColumn.column !== meta.name) {
+      setSortedColumn({
+        column: meta.name,
+        direction: 'desc',
+      });
+    } else {
+      setSortedColumn({
+        column: sortedColumn.column,
+        direction: sortedColumn.direction === 'desc' ? 'asc' : 'desc',
+      });
+    }
+  };
+
   return (
     <Accordion
       closedByDefault
@@ -152,9 +185,12 @@ const Charges = ({ request }) => {
                 ),
               }}
               columnWidths={{ description: 300 }}
-              contentData={request?.charges}
+              contentData={sortedCharges}
               formatter={formatter}
+              onHeaderClick={onHeaderClick}
               onRowClick={handleRowClick}
+              sortDirection={`${sortedColumn.direction}ending`}
+              sortedColumn={sortedColumn.column}
               visibleColumns={[
                 'description',
                 'amount',

--- a/src/components/PublicationRequestSections/Charges/Charges.js
+++ b/src/components/PublicationRequestSections/Charges/Charges.js
@@ -14,6 +14,7 @@ import {
   Col,
   MessageBanner,
   Layout,
+  Tooltip,
 } from '@folio/stripes/components';
 
 import urls from '../../../util/urls';
@@ -70,6 +71,36 @@ const Charges = ({ request }) => {
     );
   };
 
+  const renderInvoiceLineLink = (charge) => {
+    return charge?.invoiceLineItemReference ? (
+      <Tooltip
+        text={
+          <FormattedMessage
+            id="ui-oa.charge.linkToInvoiceLineIndex"
+            values={{ index: charge.rowIndex + 1 }}
+          />
+        }
+      >
+        {({ ref, ariaIds }) => (
+          <a
+            ref={ref}
+            aria-describedby={ariaIds.sub}
+            aria-labelledby={ariaIds.text}
+            href={urls.invoiceLine(
+              charge?.invoiceReference,
+              charge?.invoiceLineItemReference
+            )}
+            onClick={(e) => e.stopPropagation()}
+          >
+            {charge?.chargeStatus?.label}
+          </a>
+        )}
+      </Tooltip>
+    ) : (
+      charge?.chargeStatus?.label
+    );
+  };
+
   const formatter = {
     description: (e) => {
       return (
@@ -78,7 +109,7 @@ const Charges = ({ request }) => {
             <strong>
               <FormattedMessage id="ui-oa.charge.status" />:{' '}
             </strong>
-            {e?.chargeStatus?.label}
+            {renderInvoiceLineLink(e)}
           </div>
           <div>
             <strong>

--- a/src/components/PublicationRequestSections/Charges/Charges.js
+++ b/src/components/PublicationRequestSections/Charges/Charges.js
@@ -33,7 +33,7 @@ const Charges = ({ request }) => {
   });
 
   const sortFormatter = {
-    requestStatus: ['chargeStatus.value', 'category.value', 'payer.value'],
+    description: ['chargeStatus.value', 'category.value', 'payer.value'],
     amount: ['amount.value'],
     estimatedPrices: ['estimatedPrice.value', 'estimatedInvoicePrice.value'],
   };

--- a/translations/ui-oa/en.json
+++ b/translations/ui-oa/en.json
@@ -221,7 +221,7 @@
   "charge.type.subtracted": "{currency}",
 
   "charge.category": "Category",
-  "charge.linkToInvoiceLineIndex": "Link to invoice line {index}",
+  "charge.linkToInvoiceLineIndex": "View invoice line for charge {index}",
   "charge.status": "Status",
   "charge.payer": "Payer",
   "charge.payerNote": "Payer note",

--- a/translations/ui-oa/en.json
+++ b/translations/ui-oa/en.json
@@ -221,6 +221,7 @@
   "charge.type.subtracted": "{currency}",
 
   "charge.category": "Category",
+  "charge.linkToInvoiceLineIndex": "Link to invoice line {index}",
   "charge.status": "Status",
   "charge.payer": "Payer",
   "charge.payerNote": "Payer note",

--- a/translations/ui-oa/en.json
+++ b/translations/ui-oa/en.json
@@ -241,7 +241,7 @@
   "charge.delete": "Delete",
   "charge.deleteCharge": "Delete charge",
   "charge.deleteChargeMessage": "This charge will be permanently deleted.",
-  "charge.estimatedPrices": "Estimated prices",
+  "charge.estimatedAmount": "Estimated amount inc. discounts and tax",
   "charge.estimatedPriceLocal": "Estimated price ({localCurrency})",
   "charge.estimatedPriceSpecified": "Estimated price ({specifiedCurrency})",
   "charge.invoice.newInvoice": "New Invoice",

--- a/translations/ui-oa/en_US.json
+++ b/translations/ui-oa/en_US.json
@@ -204,7 +204,7 @@
     "charge.delete": "Delete",
     "charge.deleteCharge": "Delete charge",
     "charge.deleteChargeMessage": "This charge will be permanently deleted.",
-    "charge.estimatedPrices": "Estimated prices",
+    "charge.estimatedAmount": "Estimated amount inc. discounts and tax",
     "charge.estimatedPriceLocal": "Estimated price ({localCurrency})",
     "charge.estimatedPriceSpecified": "Estimated price ({specifiedCurrency})",
     "party.new": "New",


### PR DESCRIPTION
Now using react-intl tooling for currency symbol handling
Added a link to charge status within description column which links to related invoice line
Changed "Estimated price" column to "Estimated prices inc. tax and discounts"
Estimated prices column no longer displays the specified conversion if the local and specified currency are the same
Charges MCL are now sortable and can now are sorted by default

UIOA-106