### PR TITLE
fix: Form multiple submit

### DIFF
--- a/src/components/Modals/InvoiceLineModal/InvoiceLineModal.js
+++ b/src/components/Modals/InvoiceLineModal/InvoiceLineModal.js
@@ -8,7 +8,7 @@ import {
   Row,
   Col,
   KeyValue,
-  ConfirmationModal
+  ConfirmationModal,
 } from '@folio/stripes/components';
 
 const propTypes = {
@@ -41,12 +41,15 @@ const InvoiceLineModal = ({
     setShowModal(false);
   };
 
-  const { mutateAsync: postInvoiceLine } = useMutation(
+  const { mutateAsync: postInvoiceLine, isLoading: isSubmitting } = useMutation(
     ['ui-oa', 'InvoiceLineModal', 'postInvoiceLine'],
-    (data) => ky.post('invoice/invoice-lines', { json: data }).json().then((res) => {
-        handleInvoiceLineChange(res);
-        handleClose();
-    })
+    (data) => ky
+        .post('invoice/invoice-lines', { json: data })
+        .json()
+        .then((res) => {
+          handleInvoiceLineChange(res);
+          handleClose();
+        })
   );
 
   const renderModalMessage = () => {
@@ -83,9 +86,7 @@ const InvoiceLineModal = ({
         </Row>
         <Row>
           <Col xs={12}>
-            <FormattedMessage
-              id="ui-oa.charge.invoiceLine.newInvoiceLineConfirmMessage"
-            />
+            <FormattedMessage id="ui-oa.charge.invoiceLine.newInvoiceLineConfirmMessage" />
           </Col>
         </Row>
       </>
@@ -99,7 +100,11 @@ const InvoiceLineModal = ({
       }
       message={renderModalMessage()}
       onCancel={() => setShowModal(false)}
-      onConfirm={() => postInvoiceLine(chargeInvoiceLine)}
+      onConfirm={() => {
+        if (!isSubmitting) {
+          postInvoiceLine(chargeInvoiceLine);
+        }
+      }}
       open={showModal}
     />
   );

--- a/src/components/views/ChargeForm/ChargeForm.js
+++ b/src/components/views/ChargeForm/ChargeForm.js
@@ -20,12 +20,19 @@ const propTypes = {
     onClose: PropTypes.func.isRequired,
     onSubmit: PropTypes.func.isRequired,
   }).isRequired,
-  isLoading: PropTypes.bool,
+  queryStates: PropTypes.shape({
+    isLoading: PropTypes.bool,
+    isSubmitting: PropTypes.bool,
+  }),
   charge: PropTypes.object,
 };
 
-const ChargeForm = ({ handlers: { onClose, onSubmit }, isLoading, charge }) => {
-  const { submitting, pristine } = useFormState();
+const ChargeForm = ({
+  handlers: { onClose, onSubmit },
+  queryStates: { isLoading, isSubmitting },
+  charge,
+}) => {
+  const { pristine } = useFormState();
 
   const renderPaneTitle = () => (charge ? (
     <FormattedMessage id="ui-oa.charge.editCharge" />
@@ -56,7 +63,7 @@ const ChargeForm = ({ handlers: { onClose, onSubmit }, isLoading, charge }) => {
         renderEnd={
           <Button
             buttonStyle="primary mega"
-            disabled={pristine || submitting}
+            disabled={pristine || isSubmitting}
             marginBottom0
             onClick={onSubmit}
             type="submit"

--- a/src/components/views/ChargeForm/ChargeForm.test.js
+++ b/src/components/views/ChargeForm/ChargeForm.test.js
@@ -21,7 +21,10 @@ describe('ChargeInfoForm', () => {
     beforeEach(() => {
       renderComponent = renderWithIntl(
         <TestForm onSubmit={onSubmit}>
-          <ChargeForm handlers={handlers} />
+          <ChargeForm
+            handlers={handlers}
+            queryStates={{ isLoading: false, isSubmitting: false }}
+          />
         </TestForm>,
         translationsProperties
       );
@@ -52,7 +55,11 @@ describe('ChargeInfoForm', () => {
     beforeEach(() => {
       renderComponent = renderWithIntl(
         <TestForm onSubmit={onSubmit}>
-          <ChargeForm charge={charge} handlers={handlers} />
+          <ChargeForm
+            charge={charge}
+            handlers={handlers}
+            queryStates={{ isLoading: false, isSubmitting: false }}
+          />
         </TestForm>,
         translationsProperties
       );

--- a/src/components/views/CorrespondenceForm/CorrespondenceForm.js
+++ b/src/components/views/CorrespondenceForm/CorrespondenceForm.js
@@ -20,19 +20,26 @@ const propTypes = {
     onClose: PropTypes.func.isRequired,
     onSubmit: PropTypes.func.isRequired,
   }).isRequired,
-  isLoading: PropTypes.bool,
+  queryStates: PropTypes.shape({
+    isLoading: PropTypes.bool,
+    isSubmitting: PropTypes.bool,
+  }),
   correspondence: PropTypes.object,
 };
 
+const CorrespondenceForm = ({
+  handlers: { onClose, onSubmit },
+  queryStates: { isLoading, isSubmitting },
+  correspondence,
+}) => {
+  const { pristine } = useFormState();
 
-const CorrespondenceForm = ({ handlers: { onClose, onSubmit }, isLoading, correspondence }) => {
-  const { submitting, pristine } = useFormState();
-
-  const renderPaneTitle = () => (
-    correspondence ?
-      <FormattedMessage id="ui-oa.correspondence.editCorrespondence" /> :
+  const renderPaneTitle = () => (correspondence ? (
+    <FormattedMessage id="ui-oa.correspondence.editCorrespondence" />
+    ) : (
       <FormattedMessage id="ui-oa.correspondence.newCorrespondence" />
-  );
+    ));
+
   const renderFirstMenu = () => {
     return (
       <PaneMenu>
@@ -56,7 +63,7 @@ const CorrespondenceForm = ({ handlers: { onClose, onSubmit }, isLoading, corres
         renderEnd={
           <Button
             buttonStyle="primary mega"
-            disabled={pristine || submitting}
+            disabled={pristine || isSubmitting}
             marginBottom0
             onClick={onSubmit}
             type="submit"

--- a/src/components/views/CorrespondenceForm/CorrespondenceForm.test.js
+++ b/src/components/views/CorrespondenceForm/CorrespondenceForm.test.js
@@ -25,7 +25,10 @@ describe('CorrespondenceForm', () => {
     beforeEach(() => {
       renderComponent = renderWithIntl(
         <TestForm onSubmit={onSubmit}>
-          <CorrespondenceForm handlers={handlers} />
+          <CorrespondenceForm
+            handlers={handlers}
+            queryStates={{ isLoading: false, isSubmitting: false }}
+          />
         </TestForm>,
         translationsProperties
       );
@@ -59,6 +62,7 @@ describe('CorrespondenceForm', () => {
           <CorrespondenceForm
             correspondence={correspondence}
             handlers={handlers}
+            queryStates={{ isLoading: false, isSubmitting: false }}
           />{' '}
         </TestForm>,
         translationsProperties

--- a/src/components/views/CorrespondenceView/CorrespondenceView.test.js
+++ b/src/components/views/CorrespondenceView/CorrespondenceView.test.js
@@ -8,7 +8,7 @@ import {
   handlers,
 } from '../../../../test/resources/correspondenceResources';
 
-describe('CorrespondenceForm', () => {
+describe('CorrespondenceView', () => {
   describe('renders components', () => {
     beforeEach(() => {
       renderWithIntl(

--- a/src/components/views/LinkInvoiceForm/LinkInvoiceForm.js
+++ b/src/components/views/LinkInvoiceForm/LinkInvoiceForm.js
@@ -21,11 +21,18 @@ const propTypes = {
     onClose: PropTypes.func.isRequired,
     onSubmit: PropTypes.func.isRequired,
   }).isRequired,
+  queryStates: PropTypes.shape({
+    isSubmitting: PropTypes.bool,
+  }),
   charge: PropTypes.object,
 };
 
-const LinkInvoiceForm = ({ handlers: { onClose, onSubmit }, charge }) => {
-  const { values, pristine, submitting } = useFormState();
+const LinkInvoiceForm = ({
+  handlers: { onClose, onSubmit },
+  queryStates: { isSubmitting },
+  charge,
+}) => {
+  const { values, pristine } = useFormState();
 
   const getSectionProps = (name) => {
     return {
@@ -60,7 +67,7 @@ const LinkInvoiceForm = ({ handlers: { onClose, onSubmit }, charge }) => {
         renderEnd={
           <Button
             buttonStyle="primary mega"
-            disabled={pristine || submitting}
+            disabled={pristine || isSubmitting}
             marginBottom0
             onClick={onSubmit}
             type="submit"

--- a/src/components/views/PartyForm/PartyForm.js
+++ b/src/components/views/PartyForm/PartyForm.js
@@ -24,14 +24,21 @@ const propTypes = {
     onClose: PropTypes.func.isRequired,
     onSubmit: PropTypes.func.isRequired,
   }).isRequired,
+  queryStates: PropTypes.shape({
+    isLoading: PropTypes.bool,
+    isSubmitting: PropTypes.bool,
+  }),
   party: PropTypes.object,
-  isLoading: PropTypes.bool,
 };
 
 // TODO Replace StreetAddress with StreetAddresses when domain model supports multiple street addresses
 
-const PartyForm = ({ handlers: { onClose, onSubmit }, party, isLoading }) => {
-  const { submitting, pristine } = useFormState();
+const PartyForm = ({
+  handlers: { onClose, onSubmit },
+  queryStates: { isLoading, isSubmitting },
+  party,
+}) => {
+  const { pristine } = useFormState();
 
   const renderPaneTitle = () => (party ? (
     <FormattedMessage id="ui-oa.party.editPerson" />
@@ -45,7 +52,7 @@ const PartyForm = ({ handlers: { onClose, onSubmit }, party, isLoading }) => {
         renderEnd={
           <Button
             buttonStyle="primary mega"
-            disabled={pristine || submitting}
+            disabled={pristine || isSubmitting}
             marginBottom0
             onClick={onSubmit}
             type="submit"

--- a/src/components/views/PartyForm/PartyForm.test.js
+++ b/src/components/views/PartyForm/PartyForm.test.js
@@ -21,7 +21,10 @@ describe('PartyForm', () => {
     beforeEach(() => {
       renderComponent = renderWithIntl(
         <TestForm onSubmit={onSubmit}>
-          <PartyForm handlers={handlers} />
+          <PartyForm
+            handlers={handlers}
+            queryStates={{ isLoading: false, isSubmitting: false }}
+          />
         </TestForm>,
         translationsProperties
       );
@@ -52,7 +55,12 @@ describe('PartyForm', () => {
     beforeEach(() => {
       renderComponent = renderWithIntl(
         <TestForm onSubmit={onSubmit}>
-          <PartyForm handlers={handlers} party={party} />,
+          <PartyForm
+            handlers={handlers}
+            party={party}
+            queryStates={{ isLoading: false, isSubmitting: false }}
+          />
+          ,
         </TestForm>,
         translationsProperties
       );

--- a/src/components/views/PublicationRequestForm/PublicationRequestForm.js
+++ b/src/components/views/PublicationRequestForm/PublicationRequestForm.js
@@ -38,16 +38,19 @@ const propTypes = {
     onClose: PropTypes.func.isRequired,
     onSubmit: PropTypes.func.isRequired,
   }).isRequired,
+  queryStates: PropTypes.shape({
+    isLoading: PropTypes.bool,
+    isSubmitting: PropTypes.bool,
+  }),
   publicationRequest: PropTypes.object,
-  isLoading: PropTypes.bool,
 };
 
 const PublicationRequestForm = ({
   handlers: { onClose, onSubmit },
+  queryStates: { isLoading, isSubmitting },
   publicationRequest,
-  isLoading,
 }) => {
-  const { values, submitting, pristine } = useFormState();
+  const { values, pristine } = useFormState();
   const { change } = useForm();
   const accordionStatusRef = React.createRef();
 
@@ -81,7 +84,7 @@ const PublicationRequestForm = ({
         renderEnd={
           <Button
             buttonStyle="primary mega"
-            disabled={pristine || submitting}
+            disabled={pristine || isSubmitting}
             marginBottom0
             onClick={onSubmit}
             type="submit"

--- a/src/routes/ChargeCreateRoute/ChargeCreateRoute.js
+++ b/src/routes/ChargeCreateRoute/ChargeCreateRoute.js
@@ -20,7 +20,7 @@ const ChargeCreateRoute = () => {
     history.push(`/oa/publicationRequests/${id}`);
   };
 
-  const { mutateAsync: postCharge } = useMutation(
+  const { mutateAsync: postCharge, isLoading: isSubmitting } = useMutation(
     ['ui-oa', 'ChargeCreateRoute', 'postCharge'],
     (data) => ky.put(`oa/publicationRequest/${id}`, { json: data }).then(() => {
         handleClose();
@@ -59,6 +59,9 @@ const ChargeCreateRoute = () => {
             handlers={{
               onClose: handleClose,
               onSubmit: handleSubmit,
+            }}
+            queryStates={{
+              isSubmitting,
             }}
           />
         </form>

--- a/src/routes/ChargeEditRoute/ChargeEditRoute.js
+++ b/src/routes/ChargeEditRoute/ChargeEditRoute.js
@@ -21,7 +21,7 @@ const ChargeEditRoute = () => {
 
   const charge = publicationRequest?.charges?.find((e) => e?.id === chId);
 
-  const { mutateAsync: putCharge } = useMutation(
+  const { mutateAsync: putCharge, isLoading: isSubmitting } = useMutation(
     ['ui-oa', 'ChargeCreateRoute', 'postCharge'],
     (data) => ky.put(`oa/publicationRequest/${prId}`, { json: data }).then(() => {
         handleClose();
@@ -57,7 +57,10 @@ const ChargeEditRoute = () => {
               onClose: handleClose,
               onSubmit: handleSubmit,
             }}
-            isLoading={isLoading}
+            queryStates={{
+              isLoading,
+              isSubmitting,
+            }}
           />
         </form>
       )}

--- a/src/routes/CorrespondenceCreateRoute/CorrespondenceCreateRoute.js
+++ b/src/routes/CorrespondenceCreateRoute/CorrespondenceCreateRoute.js
@@ -14,7 +14,7 @@ const CorrespondenceCreateRoute = () => {
     history.push(`/oa/publicationRequests/${id}`);
   };
 
-  const { mutateAsync: postCorrespondence } = useMutation(
+  const { mutateAsync: postCorrespondence, isLoading: isSubmitting } = useMutation(
     ['ui-oa', 'CorrespondenceCreateRoute', 'postCorrespondence'],
     (data) => ky.post('oa/correspondence', { json: data }).json().then(() => {
         handleClose();
@@ -33,6 +33,9 @@ const CorrespondenceCreateRoute = () => {
             handlers={{
               onClose: handleClose,
               onSubmit: handleSubmit,
+            }}
+            queryStates={{
+              isSubmitting
             }}
           />
         </form>

--- a/src/routes/CorrespondenceEditRoute/CorrespondenceEditRoute.js
+++ b/src/routes/CorrespondenceEditRoute/CorrespondenceEditRoute.js
@@ -21,12 +21,13 @@ const CorrespondenceEditRoute = () => {
     () => ky(`oa/correspondence/${cId}`).json()
   );
 
-  const { mutateAsync: putCorrespondence } = useMutation(
-    ['ui-oa', 'CorrespondenceEditRoute', 'putCorrespondence'],
-    (data) => ky.put(`oa/correspondence/${cId}`, { json: data }).then(() => {
-        handleClose();
-      })
-  );
+  const { mutateAsync: putCorrespondence, isLoading: isSubmitting } =
+    useMutation(
+      ['ui-oa', 'CorrespondenceEditRoute', 'putCorrespondence'],
+      (data) => ky.put(`oa/correspondence/${cId}`, { json: data }).then(() => {
+          handleClose();
+        })
+    );
   const submitCorrespondence = (values) => {
     const { category, ...submitValues } = { ...values };
     if (category?.id) {
@@ -51,7 +52,10 @@ const CorrespondenceEditRoute = () => {
               onClose: handleClose,
               onSubmit: handleSubmit,
             }}
-            isLoading={isLoading}
+            queryStates={{
+              isSubmitting,
+              isLoading,
+            }}
           />
         </form>
       )}

--- a/src/routes/LinkInvoiceRoute/LinkInvoiceRoute.js
+++ b/src/routes/LinkInvoiceRoute/LinkInvoiceRoute.js
@@ -24,7 +24,7 @@ const LinkInvoiceRoute = () => {
     () => ky(`oa/publicationRequest/${prId}`).json()
   );
 
-  const { mutateAsync: linkInvoice } = useMutation(
+  const { mutateAsync: linkInvoice, isLoading: isSubmitting } = useMutation(
     ['ui-oa', 'LinkInvoiceRoute', 'linkInvoice'],
     (data) => ky.put(`oa/publicationRequest/${prId}`, { json: data }).then(() => {
         handleClose();
@@ -56,6 +56,9 @@ const LinkInvoiceRoute = () => {
             handlers={{
               onClose: handleClose,
               onSubmit: handleSubmit,
+            }}
+            queryStates={{
+              isSubmitting,
             }}
           />
         </form>

--- a/src/routes/PartyCreateRoute/PartyCreateRoute.js
+++ b/src/routes/PartyCreateRoute/PartyCreateRoute.js
@@ -5,7 +5,6 @@ import { useHistory } from 'react-router-dom';
 import { useMutation } from 'react-query';
 import { FormattedMessage } from 'react-intl';
 
-
 import { useOkapiKy, CalloutContext } from '@folio/stripes/core';
 
 import PartyForm from '../../components/views/PartyForm';
@@ -20,7 +19,7 @@ const PartyCreateRoute = () => {
     history.push(`/oa/people/${id}`);
   };
 
-  const { mutateAsync: postParty } = useMutation(
+  const { mutateAsync: postParty, isLoading: isSubmitting } = useMutation(
     ['ui-oa', 'PartyCreateRoute', 'postParty'],
     (data) => ky
         .post('oa/party', { json: data })
@@ -72,6 +71,9 @@ const PartyCreateRoute = () => {
             handlers={{
               onClose: handleClose,
               onSubmit: handleSubmit,
+            }}
+            queryStates={{
+              isSubmitting,
             }}
           />
         </form>

--- a/src/routes/PartyEditRoute/PartyEditRoute.js
+++ b/src/routes/PartyEditRoute/PartyEditRoute.js
@@ -10,7 +10,6 @@ import { useOkapiKy, CalloutContext } from '@folio/stripes/core';
 import PartyForm from '../../components/views/PartyForm';
 import getPartyErrorMessage from '../../util/getPartyErrorMessage';
 
-
 const PartyEditRoute = () => {
   const history = useHistory();
   const ky = useOkapiKy();
@@ -26,41 +25,44 @@ const PartyEditRoute = () => {
     () => ky(`oa/party/${id}`).json()
   );
 
-  const { mutateAsync: putParty } = useMutation(
+  const { mutateAsync: putParty, isLoading: isSubmitting } = useMutation(
     ['ui-oa', 'PartyEditRoute', 'putParty'],
-    (data) => ky.put(`oa/party/${data.id}`, { json: data }).json().then((res) => {
-      const updatedParty =
-        (res.title ? res.title + ' ' : '') +
-        res?.givenNames +
-        ' ' +
-        res?.familyName;
-      callout.sendCallout({
-        message: (
-          <FormattedMessage
-            id="ui-oa.party.updatedSuccessCallout"
-            values={{ updatedParty }}
-          />
-        ),
-        type: 'success',
-      });
-      handleClose();
-    })
-    .catch((err) => {
-      err.response.json().then((text) => {
-        if (text.total) {
-          // If there are multiple errors, map the errors onto seperate callouts.
-          text._embedded.errors.map((error) => callout.sendCallout({
-              message: getPartyErrorMessage(error?.message),
-              type: 'error',
-            }));
-        } else {
+    (data) => ky
+        .put(`oa/party/${data.id}`, { json: data })
+        .json()
+        .then((res) => {
+          const updatedParty =
+            (res.title ? res.title + ' ' : '') +
+            res?.givenNames +
+            ' ' +
+            res?.familyName;
           callout.sendCallout({
-            message: getPartyErrorMessage(text?.message),
-            type: 'error',
+            message: (
+              <FormattedMessage
+                id="ui-oa.party.updatedSuccessCallout"
+                values={{ updatedParty }}
+              />
+            ),
+            type: 'success',
           });
-        }
-      });
-    })
+          handleClose();
+        })
+        .catch((err) => {
+          err.response.json().then((text) => {
+            if (text.total) {
+              // If there are multiple errors, map the errors onto seperate callouts.
+              text._embedded.errors.map((error) => callout.sendCallout({
+                  message: getPartyErrorMessage(error?.message),
+                  type: 'error',
+                }));
+            } else {
+              callout.sendCallout({
+                message: getPartyErrorMessage(text?.message),
+                type: 'error',
+              });
+            }
+          });
+        })
   );
 
   const submitRequest = (values) => {
@@ -80,8 +82,11 @@ const PartyEditRoute = () => {
               onClose: handleClose,
               onSubmit: handleSubmit,
             }}
-            isLoading={isLoading}
             party={party}
+            queryStates={{
+              isLoading,
+              isSubmitting,
+            }}
           />
         </form>
       )}

--- a/src/routes/PublicationRequestCreateRoute/PublicationRequestCreateRoute.js
+++ b/src/routes/PublicationRequestCreateRoute/PublicationRequestCreateRoute.js
@@ -15,21 +15,31 @@ const PublicationRequestCreateRoute = () => {
   const ky = useOkapiKy();
   const callout = useContext(CalloutContext);
 
-
   const handleClose = (id) => {
     let path = '/oa/publicationRequests';
     if (id) path += `/${id}`;
     history.push(path);
   };
 
-  const { mutateAsync: postPublicationRequest } = useMutation(
-    ['ui-oa', 'PublicationRequestCreateRoute', 'postPublicationRequest'],
-    (data) => ky.post('oa/publicationRequest', { json: data }).json().then(res => {
-      const requestNumber = res.requestNumber;
-      callout.sendCallout({ message: <FormattedMessage id="ui-oa.publicationRequest.success.callout" values={{ requestNumber }} /> });
-      handleClose(res.id);
-    })
-  );
+  const { mutateAsync: postPublicationRequest, isLoading: isSubmitting } =
+    useMutation(
+      ['ui-oa', 'PublicationRequestCreateRoute', 'postPublicationRequest'],
+      (data) => ky
+          .post('oa/publicationRequest', { json: data })
+          .json()
+          .then((res) => {
+            const requestNumber = res.requestNumber;
+            callout.sendCallout({
+              message: (
+                <FormattedMessage
+                  id="ui-oa.publicationRequest.success.callout"
+                  values={{ requestNumber }}
+                />
+              ),
+            });
+            handleClose(res.id);
+          })
+    );
 
   const submitRequest = (values) => {
     const submitValues = publicationRequestSubmitHandler(values);
@@ -37,16 +47,16 @@ const PublicationRequestCreateRoute = () => {
   };
 
   return (
-    <Form
-      mutators={arrayMutators}
-      onSubmit={submitRequest}
-    >
+    <Form mutators={arrayMutators} onSubmit={submitRequest}>
       {({ handleSubmit }) => (
         <form onSubmit={handleSubmit}>
           <PublicationRequestForm
             handlers={{
               onClose: handleClose,
-              onSubmit: handleSubmit
+              onSubmit: handleSubmit,
+            }}
+            queryStates={{
+              isSubmitting,
             }}
           />
         </form>

--- a/src/routes/PublicationRequestEditRoute/PublicationRequestEditRoute.js
+++ b/src/routes/PublicationRequestEditRoute/PublicationRequestEditRoute.js
@@ -21,13 +21,13 @@ const PublicationRequestEditRoute = () => {
     () => ky(`oa/publicationRequest/${id}`).json()
   );
 
-  const { mutateAsync: putPublicationRequest } = useMutation(
-    ['ui-oa', 'PublicationRequestEditRoute', 'putPublicationRequest'],
-    (data) => ky.put(`oa/publicationRequest/${data.id}`, { json: data })
-      .then(() => {
-        handleClose();
-      })
-  );
+  const { mutateAsync: putPublicationRequest, isLoading: isSubmitting } =
+    useMutation(
+      ['ui-oa', 'PublicationRequestEditRoute', 'putPublicationRequest'],
+      (data) => ky.put(`oa/publicationRequest/${data.id}`, { json: data }).then(() => {
+          handleClose();
+        })
+    );
 
   const submitRequest = (values) => {
     const submitValues = publicationRequestSubmitHandler(values);
@@ -45,10 +45,13 @@ const PublicationRequestEditRoute = () => {
           <PublicationRequestForm
             handlers={{
               onClose: handleClose,
-              onSubmit: handleSubmit
+              onSubmit: handleSubmit,
             }}
-            isLoading={isLoading}
             publicationRequest={publicationRequest}
+            queryStates={{
+              isSubmitting,
+              isLoading,
+            }}
           />
         </form>
       )}


### PR DESCRIPTION
Fixed an issue within OA in which a forms "submit" button wasn't disabled whilst the form was being submitted, allowing the users to make multiple copies of the same record by repeatedly clicking the "submit" button, unfortunately the submitting form state prop wasn't working as intended, so I utilised the isLoading prop from the react query to handle this.