### PR TITLE
feat: Publication request values sort

### DIFF
--- a/src/components/PublicationRequestSections/Funding/Funding.js
+++ b/src/components/PublicationRequestSections/Funding/Funding.js
@@ -11,6 +11,8 @@ import {
   Row,
 } from '@folio/stripes/components';
 
+import getSortedItems from '../../../util/getSortedItems';
+
 const propTypes = {
   request: PropTypes.object,
 };
@@ -29,6 +31,10 @@ const formatter = {
 };
 
 const Funding = ({ request }) => {
+  const sortedFundings = getSortedItems(request?.fundings, null, {
+    column: 'funder.value',
+    direction: 'asc',
+  });
   return (
     <Accordion
       closedByDefault
@@ -45,7 +51,7 @@ const Funding = ({ request }) => {
                 <FormattedMessage id="ui-oa.publicationRequest.aspectFunded" />
               ),
             }}
-            contentData={request?.fundings}
+            contentData={sortedFundings}
             formatter={formatter}
             interactive={false}
             visibleColumns={['funder', 'aspectFunded']}

--- a/src/components/PublicationRequestSections/Publication/Publication.js
+++ b/src/components/PublicationRequestSections/Publication/Publication.js
@@ -14,6 +14,7 @@ import {
 import { JournalDetails, BookDetails } from '../PublicationType';
 import { publicationRequestFields } from '../../../constants';
 import ExternalLink from '../../ExternalLink';
+import getSortedItems from '../../../util/getSortedItems';
 
 const propTypes = {
   request: PropTypes.object,
@@ -55,6 +56,11 @@ const renderBadge = (request) => {
 };
 
 const Publication = ({ request }) => {
+  const sortedIdentifiers = getSortedItems(request?.identifiers, null, {
+    column: 'type.value',
+    direction: 'asc',
+  });
+
   return (
     <Accordion
       closedByDefault
@@ -166,7 +172,7 @@ const Publication = ({ request }) => {
                 <FormattedMessage id="ui-oa.identifiers.identifier" />
               ),
             }}
-            contentData={request?.identifiers}
+            contentData={sortedIdentifiers}
             formatter={formatter}
             interactive={false}
             visibleColumns={['type', 'publicationIdentifier']}

--- a/src/components/PublicationRequestSections/PublicationStatus/PublicationStatus.js
+++ b/src/components/PublicationRequestSections/PublicationStatus/PublicationStatus.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 
 import { FormattedMessage } from 'react-intl';
@@ -10,6 +9,8 @@ import {
   Row,
   FormattedUTCDate,
 } from '@folio/stripes/components';
+
+import getSortedItems from '../../../util/getSortedItems';
 
 const propTypes = {
   request: PropTypes.object,
@@ -29,6 +30,11 @@ const renderBadge = (publicationStatuses) => {
 };
 
 const PublicationStatus = ({ request }) => {
+  const sortedStatuses = getSortedItems(request?.publicationStatuses, null, {
+    column: 'statusDate',
+    direction: 'desc',
+  });
+
   return (
     <Accordion
       closedByDefault
@@ -52,7 +58,7 @@ const PublicationStatus = ({ request }) => {
             ),
           }}
           columnWidths={{ statusNote: 300 }}
-          contentData={request?.publicationStatuses}
+          contentData={sortedStatuses}
           formatter={formatter}
           interactive={false}
           visibleColumns={['publicationStatus', 'statusDate', 'statusNote']}

--- a/src/components/PublicationRequestSections/RequestInfo/RequestInfo.js
+++ b/src/components/PublicationRequestSections/RequestInfo/RequestInfo.js
@@ -54,9 +54,13 @@ const RequestInfo = ({ request }) => {
             value={
               request?.externalRequestIds?.length > 0 && (
                 <ul>
-                  {request?.externalRequestIds?.map((requestId) => (
-                    <li key={requestId?.id}>{requestId?.externalId}</li>
-                  ))}
+                  {request?.externalRequestIds
+                    ?.sort((a, b) => {
+                      return a?.externalId < b?.externalId ? -1 : 1;
+                    })
+                    .map((requestId) => (
+                      <li key={requestId?.id}>{requestId?.externalId}</li>
+                    ))}
                 </ul>
               )
             }


### PR DESCRIPTION
Repeatable values within the publication request view panes are now sorted upon render, the MCLs are not sorted as this is purely more for consistency, the fields are external request ids, publication requests, identifiers and fundings