### PR TITLE
feat: Empty sections tweaks

### DIFF
--- a/src/components/PublicationRequestFormSections/PublicationForm/PublicationForm/PublicationForm.js
+++ b/src/components/PublicationRequestFormSections/PublicationForm/PublicationForm/PublicationForm.js
@@ -164,7 +164,7 @@ const PublicationForm = () => {
       <Row middle="xs">
         <Col xs>
           <Headline margin="small" size="large" tag="h3">
-            <FormattedMessage id="ui-oa.publicationRequest.identifiers" />
+            <FormattedMessage id="ui-oa.identifiers.otherIdentifiers" />
           </Headline>
         </Col>
       </Row>

--- a/src/components/PublicationRequestSections/Charges/Charges.js
+++ b/src/components/PublicationRequestSections/Charges/Charges.js
@@ -219,6 +219,9 @@ const Charges = ({ request }) => {
               columnWidths={{ description: 300 }}
               contentData={sortedCharges}
               formatter={formatter}
+              isEmptyMessage={
+                <FormattedMessage id="ui-oa.publicationRequest.emptyCharges" />
+              }
               onHeaderClick={onHeaderClick}
               onRowClick={handleRowClick}
               sortDirection={`${sortedColumn.direction}ending`}

--- a/src/components/PublicationRequestSections/Correspondence/Correspondence.js
+++ b/src/components/PublicationRequestSections/Correspondence/Correspondence.js
@@ -128,8 +128,7 @@ const Correspondence = ({ request }) => {
             {e?.mode?.label}
           </div>
           <div>
-            {e?.content.length > 255 &&
-              renderShowMoreButton(e?.id)}
+            {e?.content.length > 255 && renderShowMoreButton(e?.id)}
             {renderEditButton(e)}
           </div>
         </div>
@@ -172,6 +171,9 @@ const Correspondence = ({ request }) => {
             formatter={formatter}
             getCellClass={getCellClass}
             interactive
+            isEmptyMessage={
+              <FormattedMessage id="ui-oa.publicationRequest.emptyCorrespondence" />
+            }
             onRowClick={handleRowClick}
             visibleColumns={[
               'dateOfCorrespondence',

--- a/src/components/PublicationRequestSections/Correspondence/Correspondence.test.js
+++ b/src/components/PublicationRequestSections/Correspondence/Correspondence.test.js
@@ -26,7 +26,9 @@ describe('Correspondence', () => {
 
     test('renders Empty list', () => {
       const { getByText } = renderComponent;
-      expect(getByText('The list contains no items')).toBeInTheDocument();
+      expect(
+        getByText('No correspondence for this request')
+      ).toBeInTheDocument();
     });
   });
 

--- a/src/components/PublicationRequestSections/Funding/Funding.js
+++ b/src/components/PublicationRequestSections/Funding/Funding.js
@@ -54,6 +54,7 @@ const Funding = ({ request }) => {
             contentData={sortedFundings}
             formatter={formatter}
             interactive={false}
+            isEmptyMessage={<FormattedMessage id="ui-oa.publicationRequest.emptyFundings" />}
             visibleColumns={['funder', 'aspectFunded']}
           />
         </Col>

--- a/src/components/PublicationRequestSections/Funding/Funding.test.js
+++ b/src/components/PublicationRequestSections/Funding/Funding.test.js
@@ -26,7 +26,7 @@ describe('Funding', () => {
 
     test('renders Empty list', () => {
       const { getByText } = renderComponent;
-      expect(getByText('The list contains no items')).toBeInTheDocument();
+      expect(getByText('No funding for this request')).toBeInTheDocument();
     });
   });
 

--- a/src/components/PublicationRequestSections/Publication/Publication.js
+++ b/src/components/PublicationRequestSections/Publication/Publication.js
@@ -159,26 +159,27 @@ const Publication = ({ request }) => {
           />
         </Col>
       </Row>
-
-      <Row>
-        <Col xs={12}>
-          <Label>
-            <FormattedMessage id="ui-oa.identifiers.otherIdentifiers" />
-          </Label>
-          <MultiColumnList
-            columnMapping={{
-              type: <FormattedMessage id="ui-oa.identifiers.type" />,
-              publicationIdentifier: (
-                <FormattedMessage id="ui-oa.identifiers.identifier" />
-              ),
-            }}
-            contentData={sortedIdentifiers}
-            formatter={formatter}
-            interactive={false}
-            visibleColumns={['type', 'publicationIdentifier']}
-          />
-        </Col>
-      </Row>
+      {request?.identifiers?.length > 0 && (
+        <Row>
+          <Col xs={12}>
+            <Label>
+              <FormattedMessage id="ui-oa.identifiers.otherIdentifiers" />
+            </Label>
+            <MultiColumnList
+              columnMapping={{
+                type: <FormattedMessage id="ui-oa.identifiers.type" />,
+                publicationIdentifier: (
+                  <FormattedMessage id="ui-oa.identifiers.identifier" />
+                ),
+              }}
+              contentData={sortedIdentifiers}
+              formatter={formatter}
+              interactive={false}
+              visibleColumns={['type', 'publicationIdentifier']}
+            />
+          </Col>
+        </Row>
+      )}
       {isJournal(request) && <JournalDetails request={request} />}
       {isBook(request) && <BookDetails request={request} />}
     </Accordion>

--- a/src/components/PublicationRequestSections/Publication/Publication.test.js
+++ b/src/components/PublicationRequestSections/Publication/Publication.test.js
@@ -39,11 +39,6 @@ describe('Publication', () => {
       await KeyValue('Publication URL').has({ value: 'No value set-' });
       await KeyValue('DOI').has({ value: 'No value set-' });
     });
-
-    test('renders Empty list', () => {
-      const { getByText } = renderComponent;
-      expect(getByText('The list contains no items')).toBeInTheDocument();
-    });
   });
 
   describe('renders components with values', () => {

--- a/src/components/PublicationRequestSections/PublicationStatus/PublicationStatus.js
+++ b/src/components/PublicationRequestSections/PublicationStatus/PublicationStatus.js
@@ -8,6 +8,7 @@ import {
   MultiColumnList,
   Row,
   FormattedUTCDate,
+  Col
 } from '@folio/stripes/components';
 
 import getSortedItems from '../../../util/getSortedItems';
@@ -45,24 +46,29 @@ const PublicationStatus = ({ request }) => {
       }
     >
       <Row>
-        <MultiColumnList
-          columnMapping={{
-            publicationStatus: (
-              <FormattedMessage id="ui-oa.publicationStatus.status" />
-            ),
-            statusDate: (
-              <FormattedMessage id="ui-oa.publicationRequest.statusDate" />
-            ),
-            statusNote: (
-              <FormattedMessage id="ui-oa.publicationRequest.statusNote" />
-            ),
-          }}
-          columnWidths={{ statusNote: 300 }}
-          contentData={sortedStatuses}
-          formatter={formatter}
-          interactive={false}
-          visibleColumns={['publicationStatus', 'statusDate', 'statusNote']}
-        />
+        <Col xs={12}>
+          <MultiColumnList
+            columnMapping={{
+              publicationStatus: (
+                <FormattedMessage id="ui-oa.publicationStatus.status" />
+              ),
+              statusDate: (
+                <FormattedMessage id="ui-oa.publicationRequest.statusDate" />
+              ),
+              statusNote: (
+                <FormattedMessage id="ui-oa.publicationRequest.statusNote" />
+              ),
+            }}
+            columnWidths={{ statusNote: 300 }}
+            contentData={sortedStatuses}
+            formatter={formatter}
+            interactive={false}
+            isEmptyMessage={
+              <FormattedMessage id="ui-oa.publicationRequest.emptyPublicationStatuses" />
+            }
+            visibleColumns={['publicationStatus', 'statusDate', 'statusNote']}
+          />
+        </Col>
       </Row>
     </Accordion>
   );

--- a/src/components/PublicationRequestSections/PublicationStatus/PublicationStatus.test.js
+++ b/src/components/PublicationRequestSections/PublicationStatus/PublicationStatus.test.js
@@ -26,7 +26,7 @@ describe('PublicationStatus', () => {
 
     test('renders Empty list', () => {
       const { getByText } = renderComponent;
-      expect(getByText('The list contains no items')).toBeInTheDocument();
+      expect(getByText('No publication statuses for this request')).toBeInTheDocument();
     });
   });
 

--- a/src/components/PublicationRequestSections/RequestInfo/RequestInfo.js
+++ b/src/components/PublicationRequestSections/RequestInfo/RequestInfo.js
@@ -45,28 +45,28 @@ const RequestInfo = ({ request }) => {
         </Col>
         <Col xs={3} />
       </Row>
-      <Row start="xs">
-        <Col xs={12}>
-          <KeyValue
-            label={
-              <FormattedMessage id="ui-oa.publicationRequest.externalRequestIds" />
-            }
-            value={
-              request?.externalRequestIds?.length > 0 && (
+      {request?.externalRequestIds?.length > 0 && (
+        <Row start="xs">
+          <Col xs={12}>
+            <KeyValue
+              label={
+                <FormattedMessage id="ui-oa.publicationRequest.externalRequestIds" />
+              }
+              value={
                 <ul>
                   {request?.externalRequestIds
                     ?.sort((a, b) => {
                       return a?.externalId < b?.externalId ? -1 : 1;
                     })
-                    .map((requestId) => (
+                    ?.map((requestId) => (
                       <li key={requestId?.id}>{requestId?.externalId}</li>
                     ))}
                 </ul>
-              )
-            }
-          />
-        </Col>
-      </Row>
+              }
+            />
+          </Col>
+        </Row>
+      )}
     </>
   );
 };

--- a/src/components/PublicationRequestSections/RequestInfo/RequestInfo.test.js
+++ b/src/components/PublicationRequestSections/RequestInfo/RequestInfo.test.js
@@ -26,10 +26,6 @@ describe('RequestInfo', () => {
     test('renders Status KeyValue', async () => {
       await KeyValue('Status').exists();
     });
-
-    test('renders External request IDs KeyValue', async () => {
-      await KeyValue('External request IDs').exists();
-    });
   });
 
   describe('renders components with initial values', () => {

--- a/translations/ui-oa/en.json
+++ b/translations/ui-oa/en.json
@@ -166,6 +166,10 @@
   "publicationRequest.subtype": "Subtype",
   "publicationRequest.title": "Title",
   "publicationRequest.useCorrespondingAuthor": "Use corresponding author",
+  "publicationRequest.emptyFundings": "No funding for this request",
+  "publicationRequest.emptyPublicationStatuses": "No publication statuses for this request",
+  "publicationRequest.emptyCorrespondence": "No correspondence for this request",
+  "publicationRequest.emptyCharges": "No charges for this request",
   
   "publicationJournal.title": "Title",
   "publicationJournal.issnPrint": "ISSN (print)",


### PR DESCRIPTION
Tweaked various areas of the publication request view to display custom messages for charges, correspondence publication statuses and fundings when non have been provided, and also to hide the external request ids and  identifiers when non have been provided