### PR TITLE
fix: Publication type change

### DIFF
--- a/src/components/PublicationRequestFormSections/PublicationForm/PublicationBook/PublicationBook.js
+++ b/src/components/PublicationRequestFormSections/PublicationForm/PublicationBook/PublicationBook.js
@@ -26,8 +26,11 @@ const PublicationBook = () => {
           <Field
             backendDateStandard="YYYY-MM-DD"
             component={Datepicker}
-            label={<FormattedMessage id="ui-oa.publicationRequest.publicationYear" />}
+            label={
+              <FormattedMessage id="ui-oa.publicationRequest.publicationYear" />
+            }
             name="bookDateOfPublication"
+            parse={(v) => v}
             timeZone="UTC"
             usePortal
           />
@@ -35,8 +38,11 @@ const PublicationBook = () => {
         <Col xs={3}>
           <Field
             component={TextField}
-            label={<FormattedMessage id="ui-oa.publicationRequest.publicationPlace" />}
+            label={
+              <FormattedMessage id="ui-oa.publicationRequest.publicationPlace" />
+            }
             name="bookPlaceOfPublication"
+            parse={(v) => v}
           />
         </Col>
         <Col xs={6} />

--- a/src/components/PublicationRequestFormSections/PublicationForm/PublicationForm/PublicationForm.js
+++ b/src/components/PublicationRequestFormSections/PublicationForm/PublicationForm/PublicationForm.js
@@ -14,6 +14,7 @@ import {
 import { IdentifiersFieldArray } from '../../FieldArrays';
 import useOARefdata from '../../../../util/useOARefdata';
 import selectifyRefdata from '../../../../util/selectifyRefdata';
+import getRDVId from '../../../../util/getRDVId';
 
 import PublicationJournal from '../PublicationJournal';
 import PublicationBook from '../PublicationBook';
@@ -43,20 +44,8 @@ const PublicationForm = () => {
   const subtypeValues = selectifyRefdata(refdataValues, SUBTYPE);
   const licenseValues = selectifyRefdata(refdataValues, LICENSE);
 
-  const getRDVId = (desc, value) => {
-    // First filter by desc
-    const refdataDescValues = refdataValues?.find((rdc) => rdc.desc === desc);
-    // Then grab the values and filter by value
-    const refdataValue = refdataDescValues?.values?.find(
-      (rdv) => rdv.value === value
-    );
-    // At this point we have the refdataValue object, which is an id, a value and a label (or undefined).
-    // Return the id
-    return refdataValue?.id;
-  };
-
-  const bookId = getRDVId(PUBLICATION_TYPE, 'book');
-  const journalArticleId = getRDVId(PUBLICATION_TYPE, 'journal_article');
+  const bookId = getRDVId(refdataValues, PUBLICATION_TYPE, 'book');
+  const journalArticleId = getRDVId(refdataValues, PUBLICATION_TYPE, 'journal_article');
 
   return (
     <Accordion

--- a/src/components/PublicationRequestSections/PublicationType/BookDetails/BookDetails.js
+++ b/src/components/PublicationRequestSections/PublicationType/BookDetails/BookDetails.js
@@ -31,7 +31,11 @@ const BookDetails = ({ request }) => {
             label={
               <FormattedMessage id="ui-oa.publicationRequest.publicationYear" />
             }
-            value={<FormattedUTCDate value={request?.bookDateOfPublication} />}
+            value={
+              request?.bookDateOfPublication ? (
+                <FormattedUTCDate value={request.bookDateOfPublication} />
+              ) : null
+            }
           />
         </Col>
         <Col xs={3}>

--- a/src/routes/PublicationRequestCreateRoute/PublicationRequestCreateRoute.js
+++ b/src/routes/PublicationRequestCreateRoute/PublicationRequestCreateRoute.js
@@ -9,12 +9,23 @@ import { useOkapiKy, CalloutContext } from '@folio/stripes/core';
 
 import PublicationRequestForm from '../../components/views/PublicationRequestForm';
 import publicationRequestSubmitHandler from '../../util/publicationRequestSubmitHandler';
+import useOARefdata from '../../util/useOARefdata';
+import getRDVId from '../../util/getRDVId';
+
+const [PUBLICATION_TYPE] = ['PublicationRequest.PublicationType'];
 
 const PublicationRequestCreateRoute = () => {
   const history = useHistory();
   const ky = useOkapiKy();
   const callout = useContext(CalloutContext);
 
+  const refdataValues = useOARefdata([PUBLICATION_TYPE]);
+
+  const journalArticleId = getRDVId(
+    refdataValues,
+    PUBLICATION_TYPE,
+    'journal_article'
+  );
   const handleClose = (id) => {
     let path = '/oa/publicationRequests';
     if (id) path += `/${id}`;
@@ -42,7 +53,10 @@ const PublicationRequestCreateRoute = () => {
     );
 
   const submitRequest = (values) => {
-    const submitValues = publicationRequestSubmitHandler(values);
+    const submitValues = publicationRequestSubmitHandler(
+      values,
+      journalArticleId
+    );
     postPublicationRequest(submitValues);
   };
 

--- a/src/routes/PublicationRequestEditRoute/PublicationRequestEditRoute.js
+++ b/src/routes/PublicationRequestEditRoute/PublicationRequestEditRoute.js
@@ -6,11 +6,23 @@ import { useQuery, useMutation } from 'react-query';
 import PublicationRequestForm from '../../components/views/PublicationRequestForm';
 
 import publicationRequestSubmitHandler from '../../util/publicationRequestSubmitHandler';
+import useOARefdata from '../../util/useOARefdata';
+import getRDVId from '../../util/getRDVId';
+
+const [PUBLICATION_TYPE] = ['PublicationRequest.PublicationType'];
 
 const PublicationRequestEditRoute = () => {
   const history = useHistory();
   const ky = useOkapiKy();
   const { id } = useParams();
+
+  const refdataValues = useOARefdata([PUBLICATION_TYPE]);
+
+  const journalArticleId = getRDVId(
+    refdataValues,
+    PUBLICATION_TYPE,
+    'journal_article'
+  );
 
   const handleClose = () => {
     history.push(`/oa/publicationRequests/${id}`);
@@ -30,7 +42,10 @@ const PublicationRequestEditRoute = () => {
     );
 
   const submitRequest = (values) => {
-    const submitValues = publicationRequestSubmitHandler(values);
+    const submitValues = publicationRequestSubmitHandler(
+      values,
+      journalArticleId
+    );
     putPublicationRequest(submitValues);
   };
 

--- a/src/util/getRDVId.js
+++ b/src/util/getRDVId.js
@@ -1,0 +1,13 @@
+const getRDVId = (refdataValues, desc, value) => {
+    // First filter by desc
+    const refdataDescValues = refdataValues?.find((rdc) => rdc.desc === desc);
+    // Then grab the values and filter by value
+    const refdataValue = refdataDescValues?.values?.find(
+      (rdv) => rdv.value === value
+    );
+    // At this point we have the refdataValue object, which is an id, a value and a label (or undefined).
+    // Return the id
+    return refdataValue?.id;
+  };
+
+export default getRDVId;

--- a/src/util/publicationRequestSubmitHandler.js
+++ b/src/util/publicationRequestSubmitHandler.js
@@ -1,85 +1,61 @@
-const publicationRequestSubmitHandler = (values) => {
-  const {
-    agreement,
-    publicationType,
-    license,
-    publisher,
-    subtype,
-    useCorrespondingAuthor: _useCorrespondingAuthor,
-    correspondingAuthor,
-    requestContact,
-    work,
-    workIndexedInDOAJ,
-    workOAStatus,
-    ...submitValues
-  } = { ...values };
+const publicationRequestSubmitHandler = (values, journalArticleId) => {
+  const submitValues = { ...values };
+  const unsetValueArray = [
+    'publicationType',
+    'publisher',
+    'subtype',
+    'license',
+    'workIndexedInDOAJ',
+    'workOAStatus',
+    'work',
+  ];
+  // For all ref data selects within the publicationrequest create page, allows for the unsetting of values
+  // If the specified refdata does not have an id, then the entire property is set to null
+  unsetValueArray.forEach((e) => {
+    if (values?.[e]?.id) {
+      submitValues[e] = values[e];
+    } else {
+      submitValues[e] = null;
+    }
+  });
 
+  // If the publication type selector is set to journal/book, then the other publication type values are set to null upon saving
+  if (values?.publicationType?.id) {
+    if (values?.publicationType?.id === journalArticleId) {
+      submitValues.bookDateOfPublication = null;
+      submitValues.bookPlaceOfPublication = null;
+    } else {
+      submitValues.work = null;
+      submitValues.workOAStatus = null;
+      submitValues.workIndexedInDOAJ = null;
+    }
+  } else {
+    submitValues.bookDateOfPublication = null;
+    submitValues.bookPlaceOfPublication = null;
+    submitValues.work = null;
+    submitValues.workOAStatus = null;
+    submitValues.workIndexedInDOAJ = null;
+  }
   // Explicitly set RequestParty values to null if no partyOwner, to allow unsetting of values
   // Due to the amount of fields in publication request, this may need refactoring
-  if (requestContact?.partyOwner?.id) {
-    requestContact.role = 'request_contact';
-    submitValues.requestContact = requestContact;
+  if (values?.requestContact?.partyOwner?.id) {
+    values.requestContact.role = 'request_contact';
+    submitValues.requestContact = values.requestContact;
   } else {
     submitValues.requestContact = null;
   }
 
-  if (correspondingAuthor?.partyOwner?.id) {
-    correspondingAuthor.role = 'corresponding_author';
-    submitValues.correspondingAuthor = correspondingAuthor;
+  if (values?.correspondingAuthor?.partyOwner?.id) {
+    values.correspondingAuthor.role = 'corresponding_author';
+    submitValues.correspondingAuthor = values.correspondingAuthor;
   } else {
     submitValues.correspondingAuthor = null;
   }
 
-  if (agreement?.remoteId) {
-    submitValues.agreement = agreement;
+  if (values?.agreement?.remoteId) {
+    submitValues.agreement = values?.agreement;
   } else {
     submitValues.agreement = null;
-  }
-
-  if (publicationType?.id) {
-    submitValues.publicationType = publicationType;
-  } else {
-    submitValues.publicationType = null;
-  }
-
-  if (license?.id) {
-    submitValues.license = license;
-  } else {
-    submitValues.license = null;
-  }
-
-  if (publisher?.id) {
-    submitValues.publisher = publisher;
-  } else {
-    submitValues.publisher = null;
-  }
-
-  if (subtype?.id) {
-    submitValues.subtype = subtype;
-  } else {
-    submitValues.subtype = null;
-  }
-
-  if (workIndexedInDOAJ?.id) {
-    submitValues.workIndexedInDOAJ = workIndexedInDOAJ;
-  } else {
-    submitValues.workIndexedInDOAJ = null;
-  }
-
-  if (workOAStatus?.id) {
-    submitValues.workOAStatus = workOAStatus;
-  } else {
-    submitValues.workOAStatus = null;
-  }
-
-  if (work) {
-    submitValues.work = {
-      id: work.id,
-    };
-  } else {
-    submitValues.work = {
-      id: null,
-    };
   }
 
   return submitValues;


### PR DESCRIPTION
Fixed an issue in which both work and book information would be saved if the user filled fields for one publication type and then changed the publication type, the publication request submit handler now removed the opposing publication types fields from the submit values. This may require a bit more QA as there was a significant amount of refactoring within the publicationRequestSubmitHandler 

UIOA-108