### PR TITLE
feat: Party info tweaks

### DIFF
--- a/src/components/PartyFormSections/OtherEmailsFieldArray/OtherEmailsFieldArray.js
+++ b/src/components/PartyFormSections/OtherEmailsFieldArray/OtherEmailsFieldArray.js
@@ -23,6 +23,7 @@ const OtherEmailsField = ({ fields: { name } }) => {
       <Label>
         <FormattedMessage id="ui-oa.otherEmail.otherEmailAddresses" />
       </Label>
+      <br />
       {items.map((email, index) => {
         return (
           <Row key={email} start="xs">

--- a/src/components/PartyFormSections/StreetAddress/StreetAddress.js
+++ b/src/components/PartyFormSections/StreetAddress/StreetAddress.js
@@ -75,8 +75,6 @@ const StreetAddress = () => {
                 <FormattedMessage id="ui-oa.party.streetAddress.country" />
               }
               name="streetAddress.address.country"
-              required
-              validate={requiredValidator}
             />
           </Col>
           <Col xs={3}>
@@ -86,8 +84,6 @@ const StreetAddress = () => {
                 <FormattedMessage id="ui-oa.party.streetAddress.postalCode" />
               }
               name="streetAddress.address.postalCode"
-              required
-              validate={requiredValidator}
             />
           </Col>
         </Row>

--- a/src/components/PartyFormSections/StreetAddress/StreetAddress.js
+++ b/src/components/PartyFormSections/StreetAddress/StreetAddress.js
@@ -1,93 +1,74 @@
 import { FormattedMessage } from 'react-intl';
 import { Field } from 'react-final-form';
 
-import { Col, Row, TextField, Card, Label } from '@folio/stripes/components';
-import { requiredValidator } from '@folio/stripes-erm-components';
+import { Col, Row, TextField, Label } from '@folio/stripes/components';
 
 const StreetAddress = () => {
   return (
     <>
       <Label>
-        <FormattedMessage id="ui-oa.party.streetAddresses" />
+        <FormattedMessage
+          id="ui-oa.party.streetAddress.index"
+          values={{ index: '' }}
+        />
       </Label>
-      <Card
-        headerStart={
-          <strong>
-            <FormattedMessage
-              id="ui-oa.party.streetAddress.index"
-              values={{ index: '' }}
-            />
-          </strong>
-        }
-        roundedBorder
-      >
-        <Row>
-          <Col xs={3}>
-            <Field
-              component={TextField}
-              label={<FormattedMessage id="ui-oa.party.streetAddress.name" />}
-              name="streetAddress.address.name"
-              parse={(v) => v}
-            />
-          </Col>
-          <Col xs={3}>
-            <Field
-              component={TextField}
-              label={
-                <FormattedMessage id="ui-oa.party.streetAddress.addressLineOne" />
-              }
-              name="streetAddress.address.addressLineOne"
-              parse={(v) => v}
-            />
-          </Col>
-          <Col xs={3}>
-            <Field
-              component={TextField}
-              label={
-                <FormattedMessage id="ui-oa.party.streetAddress.addressLineTwo" />
-              }
-              name="streetAddress.address.addressLineTwo"
-              parse={(v) => v}
-            />
-          </Col>
-          <Col xs={3}>
-            <Field
-              component={TextField}
-              label={<FormattedMessage id="ui-oa.party.streetAddress.city" />}
-              name="streetAddress.address.city"
-              parse={(v) => v}
-            />
-          </Col>
-        </Row>
-        <Row>
-          <Col xs={3}>
-            <Field
-              component={TextField}
-              label={<FormattedMessage id="ui-oa.party.streetAddress.region" />}
-              name="streetAddress.address.region"
-              parse={(v) => v}
-            />
-          </Col>
-          <Col xs={3}>
-            <Field
-              component={TextField}
-              label={
-                <FormattedMessage id="ui-oa.party.streetAddress.country" />
-              }
-              name="streetAddress.address.country"
-            />
-          </Col>
-          <Col xs={3}>
-            <Field
-              component={TextField}
-              label={
-                <FormattedMessage id="ui-oa.party.streetAddress.postalCode" />
-              }
-              name="streetAddress.address.postalCode"
-            />
-          </Col>
-        </Row>
-      </Card>
+      <br />
+      <Row>
+        <Col xs={3}>
+          <Field
+            component={TextField}
+            label={
+              <FormattedMessage id="ui-oa.party.streetAddress.addressLineOne" />
+            }
+            name="streetAddress.address.addressLineOne"
+            parse={(v) => v}
+          />
+        </Col>
+        <Col xs={3}>
+          <Field
+            component={TextField}
+            label={
+              <FormattedMessage id="ui-oa.party.streetAddress.addressLineTwo" />
+            }
+            name="streetAddress.address.addressLineTwo"
+            parse={(v) => v}
+          />
+        </Col>
+        <Col xs={3}>
+          <Field
+            component={TextField}
+            label={<FormattedMessage id="ui-oa.party.streetAddress.city" />}
+            name="streetAddress.address.city"
+            parse={(v) => v}
+          />
+        </Col>
+        <Col xs={3}>
+          <Field
+            component={TextField}
+            label={<FormattedMessage id="ui-oa.party.streetAddress.region" />}
+            name="streetAddress.address.region"
+            parse={(v) => v}
+          />
+        </Col>
+      </Row>
+      <Row>
+        <Col xs={3}>
+          <Field
+            component={TextField}
+            label={<FormattedMessage id="ui-oa.party.streetAddress.country" />}
+            name="streetAddress.address.country"
+          />
+        </Col>
+        <Col xs={3}>
+          <Field
+            component={TextField}
+            label={
+              <FormattedMessage id="ui-oa.party.streetAddress.postalCode" />
+            }
+            name="streetAddress.address.postalCode"
+          />
+        </Col>
+      </Row>
     </>
   );
 };

--- a/src/components/PartySections/PartyInfo/PartyInfo.js
+++ b/src/components/PartySections/PartyInfo/PartyInfo.js
@@ -21,7 +21,12 @@ const renderOtherEmailAddresses = (otherEmailAddresses) => {
           otherEmailAddresses && (
             <ul>
               {otherEmailAddresses.map((email) => (
-                <li key={email?.id}>{email?.email}</li>
+                <li key={email?.id}>
+                  <ExternalLink
+                    content={email?.email}
+                    href={'mailto:' + email?.email}
+                  />
+                </li>
               ))}
             </ul>
           )

--- a/src/components/PartySections/PartyInfo/PartyInfo.js
+++ b/src/components/PartySections/PartyInfo/PartyInfo.js
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import { Link, useLocation } from 'react-router-dom';
 import { FormattedMessage } from 'react-intl';
 
-import { Card, Col, KeyValue, Label, Row } from '@folio/stripes/components';
+import { Col, KeyValue, Label, Row } from '@folio/stripes/components';
 
 import ExternalLink from '../../ExternalLink';
 import urls from '../../../util/urls';
@@ -67,76 +67,52 @@ const renderIdentifiers = (party) => {
 const renderStreetAddresses = (address) => {
   return (
     <>
-      <Row>
-        <Card
-          headerStart={
-            <Label>
-              <FormattedMessage
-                id="ui-oa.party.streetAddress.index"
-                values={{ index: '' }}
-              />
-            </Label>
-          }
-          roundedBorder
-        >
-          <Row start="xs">
-            <Col xs={3}>
-              <KeyValue
-                label={<FormattedMessage id="ui-oa.party.streetAddress.name" />}
-                value={address?.name}
-              />
-            </Col>
-            <Col xs={3}>
-              <KeyValue
-                label={
-                  <FormattedMessage id="ui-oa.party.streetAddress.addressLineOne" />
-                }
-                value={address?.addressLineOne}
-              />
-            </Col>
-            <Col xs={3}>
-              <KeyValue
-                label={
-                  <FormattedMessage id="ui-oa.party.streetAddress.addressLineTwo" />
-                }
-                value={address?.addressLineTwo}
-              />
-            </Col>
-            <Col xs={3}>
-              <KeyValue
-                label={<FormattedMessage id="ui-oa.party.streetAddress.city" />}
-                value={address?.city}
-              />
-            </Col>
-          </Row>
+      <Row start="xs">
+        <Col xs={3}>
+          <KeyValue
+            label={
+              <FormattedMessage id="ui-oa.party.streetAddress.addressLineOne" />
+            }
+            value={address?.addressLineOne}
+          />
+        </Col>
+        <Col xs={3}>
+          <KeyValue
+            label={
+              <FormattedMessage id="ui-oa.party.streetAddress.addressLineTwo" />
+            }
+            value={address?.addressLineTwo}
+          />
+        </Col>
+        <Col xs={3}>
+          <KeyValue
+            label={<FormattedMessage id="ui-oa.party.streetAddress.city" />}
+            value={address?.city}
+          />
+        </Col>
 
-          <Row start="xs">
-            <Col xs={3}>
-              <KeyValue
-                label={
-                  <FormattedMessage id="ui-oa.party.streetAddress.region" />
-                }
-                value={address?.region}
-              />
-            </Col>
-            <Col xs={3}>
-              <KeyValue
-                label={
-                  <FormattedMessage id="ui-oa.party.streetAddress.country" />
-                }
-                value={address?.country}
-              />
-            </Col>
-            <Col xs={3}>
-              <KeyValue
-                label={
-                  <FormattedMessage id="ui-oa.party.streetAddress.postalCode" />
-                }
-                value={address?.postalCode}
-              />
-            </Col>
-          </Row>
-        </Card>
+        <Col xs={3}>
+          <KeyValue
+            label={<FormattedMessage id="ui-oa.party.streetAddress.region" />}
+            value={address?.region}
+          />
+        </Col>
+      </Row>
+      <Row start="xs">
+        <Col xs={3}>
+          <KeyValue
+            label={<FormattedMessage id="ui-oa.party.streetAddress.country" />}
+            value={address?.country}
+          />
+        </Col>
+        <Col xs={3}>
+          <KeyValue
+            label={
+              <FormattedMessage id="ui-oa.party.streetAddress.postalCode" />
+            }
+            value={address?.postalCode}
+          />
+        </Col>
       </Row>
     </>
   );
@@ -193,8 +169,12 @@ const PartyInfo = ({ party, isCard }) => {
         <Row>
           <Col xs={12}>
             <Label>
-              <FormattedMessage id="ui-oa.party.streetAddresses" />
+              <FormattedMessage
+                id="ui-oa.party.streetAddress.index"
+                values={{ index: '' }}
+              />
             </Label>
+            <br />
             {renderStreetAddresses(party?.streetAddress?.address)}
           </Col>
         </Row>

--- a/src/components/views/PartyForm/PartyForm.js
+++ b/src/components/views/PartyForm/PartyForm.js
@@ -106,9 +106,9 @@ const PartyForm = ({
         paneTitle={renderPaneTitle()}
       >
         <PartyInfoForm />
-        <StreetAddress />
         {/* <StreetAddressesFieldArray /> */}
         <OtherEmailsFieldArray />
+        <StreetAddress />
       </Pane>
     </Paneset>
   );


### PR DESCRIPTION
Made various tweaks to styling and functionality of party info forms;

Removed required validation for zip code and country within street address
Styled street address to no longer be contained within a card, also improved positioning of fields and separation of different sections
Other emails associated with a party are now displayed as links within the party info section

UIOA-41

DO NOT MERGE UNTIL MODOA-18
Both country and zip code fields are to be made nullable prior to merge