### PR TITLE
fix: Book year error

### DIFF
--- a/src/components/PublicationRequestSections/PublicationType/BookDetails/BookDetails.js
+++ b/src/components/PublicationRequestSections/PublicationType/BookDetails/BookDetails.js
@@ -25,10 +25,11 @@ const BookDetails = ({ request }) => {
             label={
               <FormattedMessage id="ui-oa.publicationRequest.publicationDate" />
             }
-            value={request?.bookDateOfPublication
-              .split('-')
-              .reverse()
-              .join('/')}
+            value={
+              request?.bookDateOfPublication
+                ? request.bookDateOfPublication.split('-').reverse().join('/')
+                : null
+            }
           />
         </Col>
         <Col xs={3}>


### PR DESCRIPTION
Fixed an issue in which an error would occur when a user attempted to access a publication request which had the publication type "book" but didnt have a year of publication saved