### PR TITLE
fix: Field array alignment

### DIFF
--- a/src/components/JournalFormSections/FieldArrays/InstanceIdentifiersFieldArray/InstanceIdentifiersFieldArray.js
+++ b/src/components/JournalFormSections/FieldArrays/InstanceIdentifiersFieldArray/InstanceIdentifiersFieldArray.js
@@ -31,7 +31,7 @@ const InstanceIdentifiersFieldArray = ({ instanceId }) => {
             key={identifierId}
             data-testid={`InstanceIdentifiersFieldArray[${index}]`}
           >
-            <Row middle="xs">
+            <Row>
               <Col xs={4}>
                 <Field
                   component={Select}
@@ -93,6 +93,7 @@ const InstanceIdentifiersFieldArray = ({ instanceId }) => {
                         aria-labelledby={ariaIds.text}
                         icon="trash"
                         onClick={() => fields.remove(index)}
+                        style={{ 'padding-top': '25px' }}
                       />
                     )}
                   </Tooltip>

--- a/src/components/PartyFormSections/OtherEmailsFieldArray/OtherEmailsFieldArray.js
+++ b/src/components/PartyFormSections/OtherEmailsFieldArray/OtherEmailsFieldArray.js
@@ -25,7 +25,7 @@ const OtherEmailsField = ({ fields: { name } }) => {
       </Label>
       {items.map((email, index) => {
         return (
-          <Row key={email} start="xs">
+          <Row key={email}>
             <Col xs={9}>
               <Field
                 component={TextField}
@@ -52,6 +52,7 @@ const OtherEmailsField = ({ fields: { name } }) => {
                     aria-labelledby={ariaIds.text}
                     icon="trash"
                     onClick={() => onDeleteField(index, email)}
+                    style={{ 'padding-top': '25px' }}
                   />
                 )}
               </Tooltip>

--- a/src/components/PublicationRequestFormSections/FieldArrays/ExternalRequestIdFieldArray/ExternalRequestIdFieldArray.js
+++ b/src/components/PublicationRequestFormSections/FieldArrays/ExternalRequestIdFieldArray/ExternalRequestIdFieldArray.js
@@ -25,7 +25,7 @@ const ExternalRequestIdField = ({ fields: { name } }) => {
             key={externalRequestId + index}
             data-testid={`externalRequestIdFieldArray[${index}]`}
           >
-            <Row middle="xs">
+            <Row>
               <Col xs={3}>
                 <Field
                   autoFocus={!externalRequestId?.id}
@@ -55,6 +55,7 @@ const ExternalRequestIdField = ({ fields: { name } }) => {
                       aria-labelledby={ariaIds.text}
                       icon="trash"
                       onClick={() => onDeleteField(index, externalRequestId)}
+                      style={{ 'padding-top': '25px' }}
                     />
                   )}
                 </Tooltip>

--- a/src/components/PublicationRequestFormSections/FieldArrays/FundingFieldArray/FundingFieldArray.js
+++ b/src/components/PublicationRequestFormSections/FieldArrays/FundingFieldArray/FundingFieldArray.js
@@ -34,7 +34,7 @@ const FundingField = ({ fields: { name } }) => {
       {items.map((funding, index) => {
         return (
           <div key={name + index} data-testid={`fundingFieldArray[${index}]`}>
-            <Row middle="xs">
+            <Row>
               <Col xs={3}>
                 <Field
                   autoFocus={!funding?.id}
@@ -80,6 +80,7 @@ const FundingField = ({ fields: { name } }) => {
                       aria-labelledby={ariaIds.text}
                       icon="trash"
                       onClick={() => onDeleteField(index, funding)}
+                      style={{ 'padding-top': '25px' }}
                     />
                   )}
                 </Tooltip>

--- a/src/components/PublicationRequestFormSections/FieldArrays/IdentifiersFieldArray/IdentifiersFieldArray.js
+++ b/src/components/PublicationRequestFormSections/FieldArrays/IdentifiersFieldArray/IdentifiersFieldArray.js
@@ -28,7 +28,7 @@ const IdentifiersField = ({ fields: { name } }) => {
     <>
       {items.map((identifier, index) => {
         return (
-          <Row key={identifier} middle="xs">
+          <Row key={identifier}>
             <Col xs={3}>
               <Field
                 autoFocus={!identifier?.id}
@@ -69,6 +69,7 @@ const IdentifiersField = ({ fields: { name } }) => {
                     aria-labelledby={ariaIds.text}
                     icon="trash"
                     onClick={() => onDeleteField(index, identifier)}
+                    style={{ 'padding-top': '25px' }}
                   />
                 )}
               </Tooltip>

--- a/src/components/PublicationRequestFormSections/FieldArrays/PublicationStatusFieldArray/PublicationStatusFieldArray.js
+++ b/src/components/PublicationRequestFormSections/FieldArrays/PublicationStatusFieldArray/PublicationStatusFieldArray.js
@@ -33,7 +33,6 @@ const PublicationStatusField = ({ fields: { name } }) => {
           <Row
             key={publicationStatus + index}
             data-testid={`PublicationStatusFieldArray[${index}]`}
-            start="xs"
           >
             <Col xs={3}>
               <Field
@@ -87,6 +86,7 @@ const PublicationStatusField = ({ fields: { name } }) => {
                     aria-labelledby={ariaIds.text}
                     icon="trash"
                     onClick={() => onDeleteField(index, publicationStatus)}
+                    style={{ 'padding-top': '25px' }}
                   />
                 )}
               </Tooltip>


### PR DESCRIPTION
Fixed an issue in which validation errors would cause alignment issues within the field arrays, fixed by removed the flexbox "middle" prop and by manually adjusting the css of the trash icons within each field array "padding-top: 25px"