### PR TITLE
feat: Keyboard shortcuts

### DIFF
--- a/src/components/views/ChargeForm/ChargeForm.js
+++ b/src/components/views/ChargeForm/ChargeForm.js
@@ -10,6 +10,8 @@ import {
   PaneMenu,
   IconButton,
   LoadingView,
+  HasCommand,
+  checkScope,
 } from '@folio/stripes/components';
 import { AppIcon } from '@folio/stripes/core';
 
@@ -77,24 +79,37 @@ const ChargeForm = ({ handlers: { onClose, onSubmit }, isLoading, charge }) => {
     );
   };
 
+  const shortcuts = [
+    {
+      name: 'save',
+      handler: onSubmit,
+    },
+  ];
+
   if (isLoading) {
     return <LoadingView />;
   }
 
   return (
-    <Paneset>
-      <Pane
-        appIcon={<AppIcon app="oa" />}
-        centerContent
-        defaultWidth="100%"
-        firstMenu={renderFirstMenu()}
-        footer={renderPaneFooter()}
-        id="pane.oa.charge.form"
-        paneTitle={renderPaneTitle()}
-      >
-        <ChargeInfoForm />
-      </Pane>
-    </Paneset>
+    <HasCommand
+      commands={shortcuts}
+      isWithinScope={checkScope}
+      scope={document.body}
+    >
+      <Paneset>
+        <Pane
+          appIcon={<AppIcon app="oa" />}
+          centerContent
+          defaultWidth="100%"
+          firstMenu={renderFirstMenu()}
+          footer={renderPaneFooter()}
+          id="pane.oa.charge.form"
+          paneTitle={renderPaneTitle()}
+        >
+          <ChargeInfoForm />
+        </Pane>
+      </Paneset>
+    </HasCommand>
   );
 };
 

--- a/src/components/views/ChargeView/ChargeView.js
+++ b/src/components/views/ChargeView/ChargeView.js
@@ -12,6 +12,8 @@ import {
   ConfirmationModal,
   Card,
   Row,
+  HasCommand,
+  checkScope,
 } from '@folio/stripes/components';
 
 import ChargeInfo from '../../ChargeSections/ChargeInfo';
@@ -94,6 +96,13 @@ const ChargeView = ({ charge, request, refetch }) => {
     unlinkInvoice(submitValues);
   };
 
+  const shortcuts = [
+    {
+      name: 'edit',
+      handler: () => handleEdit(),
+    },
+  ];
+
   const renderActionMenu = () => {
     return (
       <>
@@ -141,80 +150,86 @@ const ChargeView = ({ charge, request, refetch }) => {
   };
 
   return (
-    <Pane
-      actionMenu={renderActionMenu}
-      appIcon={<AppIcon app="oa" iconKey="app" size="small" />}
-      defaultWidth={PANE_DEFAULT_WIDTH}
-      dismissible
-      onClose={handleClose}
-      paneTitle={
-        <FormattedMessage id="ui-oa.charge.publicationRequestCharge" />
-      }
+    <HasCommand
+      commands={shortcuts}
+      isWithinScope={checkScope}
+      scope={document.body}
     >
-      <ConfirmationModal
-        confirmLabel={<FormattedMessage id="ui-oa.charge.delete" />}
-        heading={<FormattedMessage id="ui-oa.charge.deleteCharge" />}
-        message={<FormattedMessage id="ui-oa.charge.deleteChargeMessage" />}
-        onCancel={() => setShowDeleteConfirmModal(false)}
-        onConfirm={() => handleDelete()}
-        open={showDeleteConfirmModal}
-      />
-      <ConfirmationModal
-        confirmLabel={<FormattedMessage id="ui-oa.charge.invoice.unlink" />}
-        heading={<FormattedMessage id="ui-oa.charge.invoice.unlinkInvoice" />}
-        message={
-          <FormattedMessage id="ui-oa.charge.invoice.unlinkInvoiceMessage" />
+      <Pane
+        actionMenu={renderActionMenu}
+        appIcon={<AppIcon app="oa" iconKey="app" size="small" />}
+        defaultWidth={PANE_DEFAULT_WIDTH}
+        dismissible
+        onClose={handleClose}
+        paneTitle={
+          <FormattedMessage id="ui-oa.charge.publicationRequestCharge" />
         }
-        onCancel={() => setShowUnlinkConfirmModal(false)}
-        onConfirm={() => handleUnlink()}
-        open={showUnlinkConfirmModal}
-      />
-      <ChargeInfo charge={charge} request={request} />
-      {invoice && (
-        <Row>
-          <Card
-            cardStyle="positive"
-            headerStart={
-              <AppIcon app="invoice" size="small">
-                <Link to={urls?.invoice(charge?.invoiceReference)}>
-                  <strong>{invoice?.vendorInvoiceNo}</strong>
-                </Link>
-              </AppIcon>
-            }
-            roundedBorder
-          >
-            <InvoiceInfo charge={charge} invoice={invoice} />
-          </Card>
-        </Row>
-      )}
-      {invoiceLine && (
-        <Row>
-          <Card
-            cardStyle="positive"
-            headerStart={
-              <AppIcon app="invoice" size="small">
-                <strong>
-                  <Link
-                    to={urls?.invoiceLine(
-                      charge?.invoiceReference,
-                      charge?.invoiceLineItemReference
-                    )}
-                  >
-                    {invoiceLine?.invoiceLineNumber}
-                    {invoiceLine?.description?.length > 50
-                      ? ', ' + invoiceLine?.description.substr(0, 49) + '...'
-                      : ', ' + invoiceLine?.description}
+      >
+        <ConfirmationModal
+          confirmLabel={<FormattedMessage id="ui-oa.charge.delete" />}
+          heading={<FormattedMessage id="ui-oa.charge.deleteCharge" />}
+          message={<FormattedMessage id="ui-oa.charge.deleteChargeMessage" />}
+          onCancel={() => setShowDeleteConfirmModal(false)}
+          onConfirm={() => handleDelete()}
+          open={showDeleteConfirmModal}
+        />
+        <ConfirmationModal
+          confirmLabel={<FormattedMessage id="ui-oa.charge.invoice.unlink" />}
+          heading={<FormattedMessage id="ui-oa.charge.invoice.unlinkInvoice" />}
+          message={
+            <FormattedMessage id="ui-oa.charge.invoice.unlinkInvoiceMessage" />
+          }
+          onCancel={() => setShowUnlinkConfirmModal(false)}
+          onConfirm={() => handleUnlink()}
+          open={showUnlinkConfirmModal}
+        />
+        <ChargeInfo charge={charge} request={request} />
+        {invoice && (
+          <Row>
+            <Card
+              cardStyle="positive"
+              headerStart={
+                <AppIcon app="invoice" size="small">
+                  <Link to={urls?.invoice(charge?.invoiceReference)}>
+                    <strong>{invoice?.vendorInvoiceNo}</strong>
                   </Link>
-                </strong>
-              </AppIcon>
-            }
-            roundedBorder
-          >
-            <InvoiceLineInfo invoiceLine={invoiceLine} />
-          </Card>
-        </Row>
-      )}
-    </Pane>
+                </AppIcon>
+              }
+              roundedBorder
+            >
+              <InvoiceInfo charge={charge} invoice={invoice} />
+            </Card>
+          </Row>
+        )}
+        {invoiceLine && (
+          <Row>
+            <Card
+              cardStyle="positive"
+              headerStart={
+                <AppIcon app="invoice" size="small">
+                  <strong>
+                    <Link
+                      to={urls?.invoiceLine(
+                        charge?.invoiceReference,
+                        charge?.invoiceLineItemReference
+                      )}
+                    >
+                      {invoiceLine?.invoiceLineNumber}
+                      {invoiceLine?.description?.length > 50
+                        ? ', ' + invoiceLine?.description.substr(0, 49) + '...'
+                        : ', ' + invoiceLine?.description}
+                    </Link>
+                  </strong>
+                </AppIcon>
+              }
+              roundedBorder
+            >
+              <InvoiceLineInfo invoiceLine={invoiceLine} />
+            </Card>
+          </Row>
+        )}
+      </Pane>
+    </HasCommand>
   );
 };
 

--- a/src/components/views/CorrespondenceForm/CorrespondenceForm.js
+++ b/src/components/views/CorrespondenceForm/CorrespondenceForm.js
@@ -10,6 +10,8 @@ import {
   PaneMenu,
   IconButton,
   LoadingView,
+  HasCommand,
+  checkScope,
 } from '@folio/stripes/components';
 import { AppIcon } from '@folio/stripes/core';
 
@@ -81,24 +83,37 @@ const CorrespondenceForm = ({
     );
   };
 
+  const shortcuts = [
+    {
+      name: 'save',
+      handler: onSubmit,
+    },
+  ];
+
   if (isLoading) {
     return <LoadingView />;
   }
 
   return (
-    <Paneset>
-      <Pane
-        appIcon={<AppIcon app="oa" />}
-        centerContent
-        defaultWidth="100%"
-        firstMenu={renderFirstMenu()}
-        footer={renderPaneFooter()}
-        id="pane.oa.correspondence.form"
-        paneTitle={renderPaneTitle()}
-      >
-        <CorrespondenceInfoForm />
-      </Pane>
-    </Paneset>
+    <HasCommand
+      commands={shortcuts}
+      isWithinScope={checkScope}
+      scope={document.body}
+    >
+      <Paneset>
+        <Pane
+          appIcon={<AppIcon app="oa" />}
+          centerContent
+          defaultWidth="100%"
+          firstMenu={renderFirstMenu()}
+          footer={renderPaneFooter()}
+          id="pane.oa.correspondence.form"
+          paneTitle={renderPaneTitle()}
+        >
+          <CorrespondenceInfoForm />
+        </Pane>
+      </Paneset>
+    </HasCommand>
   );
 };
 

--- a/src/components/views/Journal/Journal.js
+++ b/src/components/views/Journal/Journal.js
@@ -11,6 +11,8 @@ import {
   Button,
   Icon,
   FormattedUTCDate,
+  HasCommand,
+  checkScope,
 } from '@folio/stripes/components';
 import JournalInstances from '../../JournalSections';
 import { PANE_DEFAULT_WIDTH } from '../../../constants/config';
@@ -103,24 +105,37 @@ const Journal = ({ resource: journal, onClose, queryProps: { isLoading } }) => {
     );
   };
 
+  const shortcuts = [
+    {
+      name: 'edit',
+      handler: () => handleEdit(),
+    },
+  ];
+
   return (
-    <Pane
-      actionMenu={renderActionMenu}
-      appIcon={<AppIcon iconKey="app" size="small" />}
-      defaultWidth={PANE_DEFAULT_WIDTH}
-      dismissible
-      onClose={onClose}
-      paneTitle={journal?.title}
+    <HasCommand
+      commands={shortcuts}
+      isWithinScope={checkScope}
+      scope={document.body}
     >
-      <JournalInstances {...getSectionProps('journalInfo')} />
-      {!!publicationRequests?.length && (
-        <RelatedRequests
-          requests={publicationRequests}
-          requestsFormatter={requestsFormatter}
-          sortFormatter={sortFormatter}
-        />
-      )}
-    </Pane>
+      <Pane
+        actionMenu={renderActionMenu}
+        appIcon={<AppIcon iconKey="app" size="small" />}
+        defaultWidth={PANE_DEFAULT_WIDTH}
+        dismissible
+        onClose={onClose}
+        paneTitle={journal?.title}
+      >
+        <JournalInstances {...getSectionProps('journalInfo')} />
+        {!!publicationRequests?.length && (
+          <RelatedRequests
+            requests={publicationRequests}
+            requestsFormatter={requestsFormatter}
+            sortFormatter={sortFormatter}
+          />
+        )}
+      </Pane>
+    </HasCommand>
   );
 };
 

--- a/src/components/views/JournalForm/JournalForm.js
+++ b/src/components/views/JournalForm/JournalForm.js
@@ -10,6 +10,8 @@ import {
   PaneMenu,
   IconButton,
   LoadingView,
+  HasCommand,
+  checkScope,
 } from '@folio/stripes/components';
 import { AppIcon } from '@folio/stripes/core';
 
@@ -54,6 +56,13 @@ const JournalForm = ({
     );
   };
 
+  const shortcuts = [
+    {
+      name: 'save',
+      handler: onSubmit,
+    },
+  ];
+
   const renderPaneFooter = () => {
     return (
       <PaneFooter
@@ -86,19 +95,25 @@ const JournalForm = ({
   }
 
   return (
-    <Paneset>
-      <Pane
-        appIcon={<AppIcon app="oa" />}
-        centerContent
-        defaultWidth="100%"
-        firstMenu={renderFirstMenu()}
-        footer={renderPaneFooter()}
-        id="pane-oa-journal-form"
-        paneTitle={renderPaneTitle()}
-      >
-        <JournalStatusForm />
-      </Pane>
-    </Paneset>
+    <HasCommand
+      commands={shortcuts}
+      isWithinScope={checkScope}
+      scope={document.body}
+    >
+      <Paneset>
+        <Pane
+          appIcon={<AppIcon app="oa" />}
+          centerContent
+          defaultWidth="100%"
+          firstMenu={renderFirstMenu()}
+          footer={renderPaneFooter()}
+          id="pane-oa-journal-form"
+          paneTitle={renderPaneTitle()}
+        >
+          <JournalStatusForm />
+        </Pane>
+      </Paneset>
+    </HasCommand>
   );
 };
 

--- a/src/components/views/LinkInvoiceForm/LinkInvoiceForm.js
+++ b/src/components/views/LinkInvoiceForm/LinkInvoiceForm.js
@@ -9,6 +9,8 @@ import {
   Paneset,
   PaneMenu,
   IconButton,
+  HasCommand,
+  checkScope,
 } from '@folio/stripes/components';
 import { AppIcon } from '@folio/stripes/core';
 import {
@@ -27,10 +29,7 @@ const propTypes = {
   charge: PropTypes.object,
 };
 
-const LinkInvoiceForm = ({
-  handlers: { onClose, onSubmit },
-  charge,
-}) => {
+const LinkInvoiceForm = ({ handlers: { onClose, onSubmit }, charge }) => {
   const { values, pristine, submitting } = useFormState();
 
   const getSectionProps = (name) => {
@@ -86,25 +85,34 @@ const LinkInvoiceForm = ({
       />
     );
   };
+
+  const shortcuts = [{ name: 'save', handler: onSubmit }];
+
   return (
-    <Paneset>
-      <Pane
-        appIcon={<AppIcon app="oa" />}
-        centerContent
-        defaultWidth="100%"
-        firstMenu={renderFirstMenu()}
-        footer={renderPaneFooter()}
-        id="pane.oa.invoice.form"
-        paneTitle={renderPaneTitle()}
-      >
-        <InvoiceTypedownForm {...getSectionProps('invoiceTypedown')} />
-        {values?.selectedInvoice && (
-          <InvoiceLineTypedownForm
-            {...getSectionProps('invoiceLineTypedown')}
-          />
-        )}
-      </Pane>
-    </Paneset>
+    <HasCommand
+      commands={shortcuts}
+      isWithinScope={checkScope}
+      scope={document.body}
+    >
+      <Paneset>
+        <Pane
+          appIcon={<AppIcon app="oa" />}
+          centerContent
+          defaultWidth="100%"
+          firstMenu={renderFirstMenu()}
+          footer={renderPaneFooter()}
+          id="pane.oa.invoice.form"
+          paneTitle={renderPaneTitle()}
+        >
+          <InvoiceTypedownForm {...getSectionProps('invoiceTypedown')} />
+          {values?.selectedInvoice && (
+            <InvoiceLineTypedownForm
+              {...getSectionProps('invoiceLineTypedown')}
+            />
+          )}
+        </Pane>
+      </Paneset>
+    </HasCommand>
   );
 };
 

--- a/src/components/views/Party/Party.js
+++ b/src/components/views/Party/Party.js
@@ -10,6 +10,8 @@ import {
   Icon,
   LoadingPane,
   FormattedUTCDate,
+  checkScope,
+  HasCommand,
 } from '@folio/stripes/components';
 
 import PartyInfo from '../../PartySections';
@@ -82,6 +84,13 @@ const Party = ({ resource: party, onClose, queryProps: { isLoading } }) => {
     history.push(`${urls.partyEdit(params?.id)}`);
   };
 
+  const shortcuts = [
+    {
+      name: 'edit',
+      handler: () => handleEdit(),
+    },
+  ];
+
   if (isLoading) {
     return (
       <LoadingPane
@@ -93,41 +102,47 @@ const Party = ({ resource: party, onClose, queryProps: { isLoading } }) => {
   }
 
   return (
-    <Pane
-      actionMenu={() => (
-        <Button
-          buttonStyle="dropdownItem"
-          id="clickable-dropdown-edit-party"
-          onClick={handleEdit}
-        >
-          <Icon icon="edit">
-            <FormattedMessage id="ui-oa.party.edit" />
-          </Icon>
-        </Button>
-      )}
-      appIcon={<AppIcon iconKey="app" size="small" />}
-      defaultWidth={PANE_DEFAULT_WIDTH}
-      dismissible
-      onClose={onClose}
-      paneTitle={
-        <FormattedMessage
-          id="ui-oa.party.familyNameOrdered"
-          values={{
-            familyName: party?.familyName,
-            givenNames: party?.givenNames,
-          }}
-        />
-      }
+    <HasCommand
+      commands={shortcuts}
+      isWithinScope={checkScope}
+      scope={document.body}
     >
-      <PartyInfo {...getSectionProps('partyInfo')} />
-      {!!publicationRequests?.length && (
-        <RelatedRequests
-          requests={publicationRequests}
-          requestsFormatter={requestsFormatter}
-          sortFormatter={sortFormatter}
-        />
-      )}
-    </Pane>
+      <Pane
+        actionMenu={() => (
+          <Button
+            buttonStyle="dropdownItem"
+            id="clickable-dropdown-edit-party"
+            onClick={handleEdit}
+          >
+            <Icon icon="edit">
+              <FormattedMessage id="ui-oa.party.edit" />
+            </Icon>
+          </Button>
+        )}
+        appIcon={<AppIcon iconKey="app" size="small" />}
+        defaultWidth={PANE_DEFAULT_WIDTH}
+        dismissible
+        onClose={onClose}
+        paneTitle={
+          <FormattedMessage
+            id="ui-oa.party.familyNameOrdered"
+            values={{
+              familyName: party?.familyName,
+              givenNames: party?.givenNames,
+            }}
+          />
+        }
+      >
+        <PartyInfo {...getSectionProps('partyInfo')} />
+        {!!publicationRequests?.length && (
+          <RelatedRequests
+            requests={publicationRequests}
+            requestsFormatter={requestsFormatter}
+            sortFormatter={sortFormatter}
+          />
+        )}
+      </Pane>
+    </HasCommand>
   );
 };
 

--- a/src/components/views/PartyForm/PartyForm.js
+++ b/src/components/views/PartyForm/PartyForm.js
@@ -10,6 +10,8 @@ import {
   Paneset,
   PaneMenu,
   LoadingView,
+  HasCommand,
+  checkScope,
 } from '@folio/stripes/components';
 import { AppIcon } from '@folio/stripes/core';
 
@@ -83,27 +85,40 @@ const PartyForm = ({ handlers: { onClose, onSubmit }, isLoading, party }) => {
     );
   };
 
+  const shortcuts = [
+    {
+      name: 'save',
+      handler: onSubmit,
+    },
+  ];
+
   if (isLoading) {
     return <LoadingView />;
   }
 
   return (
-    <Paneset>
-      <Pane
-        appIcon={<AppIcon />}
-        centerContent
-        defaultWidth="100%"
-        firstMenu={renderFirstMenu()}
-        footer={renderPaneFooter()}
-        id="pane-oa-party-form"
-        paneTitle={renderPaneTitle()}
-      >
-        <PartyInfoForm />
-        {/* <StreetAddressesFieldArray /> */}
-        <OtherEmailsFieldArray />
-        <StreetAddress />
-      </Pane>
-    </Paneset>
+    <HasCommand
+      commands={shortcuts}
+      isWithinScope={checkScope}
+      scope={document.body}
+    >
+      <Paneset>
+        <Pane
+          appIcon={<AppIcon />}
+          centerContent
+          defaultWidth="100%"
+          firstMenu={renderFirstMenu()}
+          footer={renderPaneFooter()}
+          id="pane-oa-party-form"
+          paneTitle={renderPaneTitle()}
+        >
+          <PartyInfoForm />
+          {/* <StreetAddressesFieldArray /> */}
+          <OtherEmailsFieldArray />
+          <StreetAddress />
+        </Pane>
+      </Paneset>
+    </HasCommand>
   );
 };
 

--- a/src/components/views/PublicationRequest/PublicationRequest.js
+++ b/src/components/views/PublicationRequest/PublicationRequest.js
@@ -64,6 +64,7 @@ const PublicationRequest = ({
   };
 
   const shortcuts = [
+    { name: 'edit', handler: () => handleEdit() },
     {
       name: 'expandAllSections',
       handler: (e) => expandAllSections(e, accordionStatusRef),

--- a/src/components/views/PublicationRequestForm/PublicationRequestForm.js
+++ b/src/components/views/PublicationRequestForm/PublicationRequestForm.js
@@ -38,7 +38,7 @@ const propTypes = {
     onClose: PropTypes.func.isRequired,
     onSubmit: PropTypes.func.isRequired,
   }).isRequired,
-    isLoading: PropTypes.bool,
+  isLoading: PropTypes.bool,
   publicationRequest: PropTypes.object,
 };
 
@@ -65,6 +65,7 @@ const PublicationRequestForm = ({
   }, [change, values]);
 
   const shortcuts = [
+    { name: 'save', handler: onSubmit },
     {
       name: 'expandAllSections',
       handler: (e) => expandAllSections(e, accordionStatusRef),

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,15 @@
-import React, { Suspense } from 'react';
+import { useState, Suspense } from 'react';
 import { Route, Switch } from 'react-router-dom';
 import PropTypes from 'prop-types';
+
+import {
+  CommandList,
+  importShortcuts,
+  HasCommand,
+  KeyboardShortcutsModal,
+  checkScope,
+} from '@folio/stripes/components';
+
 import Settings from './settings';
 
 import {
@@ -22,6 +31,7 @@ import {
 } from './routes';
 
 const App = (props) => {
+  const [showShortcutModal, setShowShortcutModal] = useState(false);
   const {
     actAs,
     match: { path },
@@ -35,57 +45,101 @@ const App = (props) => {
     );
   }
 
+  const keyboardShortcuts = importShortcuts([
+    'new',
+    'edit',
+    'save',
+    'expandAllSections',
+    'collapseAllSections',
+    'expandOrCollapseAccordion',
+    'search',
+    'openShortcutModal',
+  ]);
+
+  const changeShortcutsModal = () => {
+    setShowShortcutModal(!showShortcutModal);
+  };
+
+  const shortcuts = [
+    {
+      name: 'openShortcutModal',
+      handler: changeShortcutsModal,
+    },
+  ];
+
   return (
-    <Suspense fallback={null}>
-      <Switch>
-        <Route
-          component={PublicationRequestCreateRoute}
-          path={`${path}/publicationRequests/create`}
+    <>
+      <CommandList commands={keyboardShortcuts}>
+        <HasCommand
+          commands={shortcuts}
+          isWithinScope={checkScope}
+          scope={document.body}
+        >
+          <Suspense fallback={null}>
+            <Switch>
+              <Route
+                component={PublicationRequestCreateRoute}
+                path={`${path}/publicationRequests/create`}
+              />
+              <Route
+                component={PublicationRequestEditRoute}
+                path={`${path}/publicationRequests/:id/edit`}
+              />
+              <Route
+                component={CorrespondenceCreateRoute}
+                path={`${path}/publicationRequests/:id/correspondence/create`}
+              />
+              <Route
+                component={CorrespondenceEditRoute}
+                path={`${path}/publicationRequests/:prId/correspondence/:cId/edit`}
+              />
+              <Route
+                component={LinkInvoiceRoute}
+                path={`${path}/publicationRequests/:prId/charge/:chId/linkInvoice`}
+              />
+              <Route
+                component={ChargeCreateRoute}
+                path={`${path}/publicationRequests/:id/charge/create`}
+              />
+              <Route
+                component={ChargeEditRoute}
+                path={`${path}/publicationRequests/:prId/charge/:chId/edit`}
+              />
+              <Route
+                component={JournalEditRoute}
+                path={`${path}/journals/:id/edit`}
+              />
+              <Route
+                component={PartyCreateRoute}
+                path={`${path}/people/create`}
+              />
+              <Route
+                component={PartyEditRoute}
+                path={`${path}/people/:id/edit`}
+              />
+              <PartiesRoute path={`${path}/people`} />
+              <JournalsRoute path={`${path}/journals`} />
+              <PublicationRequestsRoute path={`${path}/publicationRequests`}>
+                <Route
+                  component={ChargeRoute}
+                  path={`${path}/publicationRequests/:prId/charge/:chId`}
+                />
+                <Route
+                  component={CorrespondenceViewRoute}
+                  path={`${path}/publicationRequests/:prId/correspondence/:cId`}
+                />
+              </PublicationRequestsRoute>
+            </Switch>
+          </Suspense>
+        </HasCommand>
+      </CommandList>
+      {showShortcutModal && (
+        <KeyboardShortcutsModal
+          allCommands={keyboardShortcuts}
+          onClose={changeShortcutsModal}
         />
-        <Route
-          component={PublicationRequestEditRoute}
-          path={`${path}/publicationRequests/:id/edit`}
-        />
-        <Route
-          component={CorrespondenceCreateRoute}
-          path={`${path}/publicationRequests/:id/correspondence/create`}
-        />
-        <Route
-          component={CorrespondenceEditRoute}
-          path={`${path}/publicationRequests/:prId/correspondence/:cId/edit`}
-        />
-        <Route
-          component={LinkInvoiceRoute}
-          path={`${path}/publicationRequests/:prId/charge/:chId/linkInvoice`}
-        />
-        <Route
-          component={ChargeCreateRoute}
-          path={`${path}/publicationRequests/:id/charge/create`}
-        />
-        <Route
-          component={ChargeEditRoute}
-          path={`${path}/publicationRequests/:prId/charge/:chId/edit`}
-        />
-        <Route
-          component={JournalEditRoute}
-          path={`${path}/journals/:id/edit`}
-        />
-        <Route component={PartyCreateRoute} path={`${path}/people/create`} />
-        <Route component={PartyEditRoute} path={`${path}/people/:id/edit`} />
-        <PartiesRoute path={`${path}/people`} />
-        <JournalsRoute path={`${path}/journals`} />
-        <PublicationRequestsRoute path={`${path}/publicationRequests`}>
-          <Route
-            component={ChargeRoute}
-            path={`${path}/publicationRequests/:prId/charge/:chId`}
-          />
-          <Route
-            component={CorrespondenceViewRoute}
-            path={`${path}/publicationRequests/:prId/correspondence/:cId`}
-          />
-        </PublicationRequestsRoute>
-      </Switch>
-    </Suspense>
+      )}
+    </>
   );
 };
 

--- a/src/index.js
+++ b/src/index.js
@@ -52,7 +52,8 @@ const App = (props) => {
     'expandAllSections',
     'collapseAllSections',
     'expandOrCollapseAccordion',
-    'search',
+    // Will be implemented when ID is assigned to search field in k-int components
+    // 'search',
     'openShortcutModal',
   ]);
 

--- a/src/routes/CorrespondenceEditRoute/CorrespondenceEditRoute.js
+++ b/src/routes/CorrespondenceEditRoute/CorrespondenceEditRoute.js
@@ -13,7 +13,7 @@ const CorrespondenceEditRoute = () => {
   const { prId, cId } = useParams();
 
   const handleClose = () => {
-    history.push(`/oa/publicationRequests/${prId}`);
+    history.push(`/oa/publicationRequests/${prId}/correspondence/${cId}`);
   };
 
   const { data: correspondence, isLoading } = useQuery(

--- a/src/routes/CorrespondenceViewRoute/CorrespondenceViewRoute.js
+++ b/src/routes/CorrespondenceViewRoute/CorrespondenceViewRoute.js
@@ -2,6 +2,7 @@ import { useHistory, useParams } from 'react-router-dom';
 import { useOkapiKy } from '@folio/stripes/core';
 import { useQuery, useMutation } from 'react-query';
 
+import { checkScope, HasCommand } from '@folio/stripes/components';
 import urls from '../../util/urls';
 import CorrespondenceView from '../../components/views/CorrespondenceView';
 
@@ -34,14 +35,27 @@ const CorrespondenceViewRoute = () => {
     history.push(`${urls.publicationRequestCorrespondenceEdit(prId, cId)}`);
   };
 
+  const shortcuts = [
+    {
+      name: 'edit',
+      handler: () => handleEdit(),
+    },
+  ];
+
   return (
-    <CorrespondenceView
-      correspondence={correspondence}
-      isLoading={isLoading}
-      onClose={handleClose}
-      onDelete={handleDelete}
-      onEdit={handleEdit}
-    />
+    <HasCommand
+      commands={shortcuts}
+      isWithinScope={checkScope}
+      scope={document.body}
+    >
+      <CorrespondenceView
+        correspondence={correspondence}
+        isLoading={isLoading}
+        onClose={handleClose}
+        onDelete={handleDelete}
+        onEdit={handleEdit}
+      />
+    </HasCommand>
   );
 };
 

--- a/src/routes/JournalsRoute/JournalsRoute.js
+++ b/src/routes/JournalsRoute/JournalsRoute.js
@@ -4,7 +4,12 @@ import { FormattedMessage } from 'react-intl';
 import { useHistory } from 'react-router-dom';
 
 import { AppIcon, IfPermission } from '@folio/stripes/core';
-import { Button, PaneMenu } from '@folio/stripes/components';
+import {
+  Button,
+  checkScope,
+  HasCommand,
+  PaneMenu,
+} from '@folio/stripes/components';
 import { SASQRoute } from '@k-int/stripes-kint-components';
 
 import { OAFilterHeaderComponent } from '../../components/SearchAndFilter';
@@ -37,6 +42,8 @@ const JournalsRoute = ({ path }) => {
       filterKeys: {},
     },
   };
+
+  const shortcuts = [{ name: 'new', handler: () => setShowModal(true) }];
 
   const resultColumns = [
     {
@@ -85,21 +92,27 @@ const JournalsRoute = ({ path }) => {
 
   return (
     <>
-      <SASQRoute
-        fetchParameters={fetchParameters}
-        FilterPaneHeaderComponent={renderHeaderComponent}
-        id="journals-sasq"
-        mainPaneProps={{
-          appIcon: <AppIcon iconKey="app" size="small" />,
-          lastMenu: lastpaneMenu,
-          paneTitle: <FormattedMessage id="ui-oa.journals" />,
-        }}
-        mclProps={{ formatter }}
-        path={path}
-        resultColumns={resultColumns}
-        sasqProps={{ initialSortState: { sort: 'title' } }}
-        ViewComponent={Journal}
-      />
+      <HasCommand
+        commands={shortcuts}
+        isWithinScope={checkScope}
+        scope={document.body}
+      >
+        <SASQRoute
+          fetchParameters={fetchParameters}
+          FilterPaneHeaderComponent={renderHeaderComponent}
+          id="journals-sasq"
+          mainPaneProps={{
+            appIcon: <AppIcon iconKey="app" size="small" />,
+            lastMenu: lastpaneMenu,
+            paneTitle: <FormattedMessage id="ui-oa.journals" />,
+          }}
+          mclProps={{ formatter }}
+          path={path}
+          resultColumns={resultColumns}
+          sasqProps={{ initialSortState: { sort: 'title' } }}
+          ViewComponent={Journal}
+        />
+      </HasCommand>
       <JournalModal
         handleJournalChange={handleJournalChange}
         setShowModal={setShowModal}

--- a/src/routes/PartiesRoute/PartiesRoute.js
+++ b/src/routes/PartiesRoute/PartiesRoute.js
@@ -1,9 +1,15 @@
 import PropTypes from 'prop-types';
 
 import { FormattedMessage } from 'react-intl';
+import { useHistory } from 'react-router-dom';
 
 import { AppIcon, IfPermission } from '@folio/stripes/core';
-import { Button, PaneMenu } from '@folio/stripes/components';
+import {
+  Button,
+  PaneMenu,
+  HasCommand,
+  checkScope,
+} from '@folio/stripes/components';
 
 import { SASQRoute } from '@k-int/stripes-kint-components';
 import { OAFilterHeaderComponent } from '../../components/SearchAndFilter';
@@ -11,6 +17,7 @@ import Party from '../../components/views/Party';
 import urls from '../../util/urls';
 
 const PartiesRoute = ({ path }) => {
+  const history = useHistory();
   const renderHeaderComponent = () => {
     return <OAFilterHeaderComponent primary="people" />;
   };
@@ -42,6 +49,12 @@ const PartiesRoute = ({ path }) => {
     },
   ];
 
+  const handleCreate = () => {
+    history.push(urls.partyCreate());
+  };
+
+  const shortcuts = [{ name: 'new', handler: () => handleCreate() }];
+
   const formatter = {
     givenNames: (d) => (
       <AppIcon iconAlignment="baseline" iconKey="app" size="small">
@@ -60,7 +73,7 @@ const PartiesRoute = ({ path }) => {
               buttonStyle="primary"
               id="new-party"
               marginBottom0
-              to={`${urls.partyCreate()}`}
+              onClick={() => handleCreate()}
             >
               <FormattedMessage id="stripes-smart-components.new" />
             </Button>
@@ -71,21 +84,27 @@ const PartiesRoute = ({ path }) => {
   );
 
   return (
-    <SASQRoute
-      fetchParameters={fetchParameters}
-      FilterPaneHeaderComponent={renderHeaderComponent}
-      id="parties-sasq"
-      mainPaneProps={{
-        appIcon: <AppIcon iconKey="app" size="small" />,
-        lastMenu: lastpaneMenu,
-        paneTitle: <FormattedMessage id="ui-oa.parties.people" />,
-      }}
-      mclProps={{ formatter }}
-      path={path}
-      resultColumns={resultColumns}
-      sasqProps={{ initialSortState: { sort: 'familyName,givenNames' } }}
-      ViewComponent={Party}
-    />
+    <HasCommand
+      commands={shortcuts}
+      isWithinScope={checkScope}
+      scope={document.body}
+    >
+      <SASQRoute
+        fetchParameters={fetchParameters}
+        FilterPaneHeaderComponent={renderHeaderComponent}
+        id="parties-sasq"
+        mainPaneProps={{
+          appIcon: <AppIcon iconKey="app" size="small" />,
+          lastMenu: lastpaneMenu,
+          paneTitle: <FormattedMessage id="ui-oa.parties.people" />,
+        }}
+        mclProps={{ formatter }}
+        path={path}
+        resultColumns={resultColumns}
+        sasqProps={{ initialSortState: { sort: 'familyName,givenNames' } }}
+        ViewComponent={Party}
+      />
+    </HasCommand>
   );
 };
 

--- a/src/routes/PartyCreateRoute/PartyCreateRoute.js
+++ b/src/routes/PartyCreateRoute/PartyCreateRoute.js
@@ -15,8 +15,8 @@ const PartyCreateRoute = () => {
   const ky = useOkapiKy();
   const callout = useContext(CalloutContext);
 
-  const handleClose = (id) => {
-    history.push(`/oa/people/${id}`);
+  const handleClose = () => {
+    history.push('/oa/people/');
   };
 
   const { mutateAsync: postParty } = useMutation(

--- a/src/routes/PublicationRequestsRoute/PublicationRequestsRoute.js
+++ b/src/routes/PublicationRequestsRoute/PublicationRequestsRoute.js
@@ -1,10 +1,17 @@
 import PropTypes from 'prop-types';
 
 import { FormattedMessage } from 'react-intl';
+import { useHistory } from 'react-router-dom';
 
 import { AppIcon, IfPermission } from '@folio/stripes/core';
 
-import { Button, FormattedUTCDate, PaneMenu } from '@folio/stripes/components';
+import {
+  Button,
+  FormattedUTCDate,
+  HasCommand,
+  PaneMenu,
+  checkScope,
+} from '@folio/stripes/components';
 
 import { SASQRoute } from '@k-int/stripes-kint-components';
 import PublicationRequest from '../../components/views/PublicationRequest';
@@ -15,6 +22,8 @@ import {
 } from '../../components/SearchAndFilter';
 
 const PublicationRequestsRoute = ({ children, path }) => {
+  const history = useHistory();
+
   const fetchParameters = {
     endpoint: 'oa/publicationRequest',
     SASQ_MAP: {
@@ -25,6 +34,12 @@ const PublicationRequestsRoute = ({ children, path }) => {
       },
     },
   };
+
+  const handleCreate = () => {
+    history.push(urls.publicationRequestCreate());
+  };
+
+  const shortcuts = [{ name: 'new', handler: () => handleCreate() }];
 
   const renderHeaderComponent = () => {
     return <OAFilterHeaderComponent primary="publicationRequests" />;
@@ -78,7 +93,7 @@ const PublicationRequestsRoute = ({ children, path }) => {
               buttonStyle="primary"
               id="clickable-new-publication-request"
               marginBottom0
-              to={`${urls.publicationRequestCreate()}`}
+              onClick={() => handleCreate()}
             >
               <FormattedMessage id="stripes-smart-components.new" />
             </Button>
@@ -89,27 +104,33 @@ const PublicationRequestsRoute = ({ children, path }) => {
   );
 
   return (
-    <SASQRoute
-      fetchParameters={fetchParameters}
-      FilterComponent={PublicationRequestsFilters}
-      FilterPaneHeaderComponent={renderHeaderComponent}
-      id="publication-requests"
-      mainPaneProps={{
-        appIcon: <AppIcon app="oa" iconKey="app" size="small" />,
-        lastMenu: lastpaneMenu,
-        paneTitle: <FormattedMessage id="ui-oa.publicationRequests" />,
-      }}
-      mclProps={{
-        formatter,
-        columnWidths: { publicationTitle: 500 },
-      }}
-      path={path}
-      resultColumns={resultColumns}
-      sasqProps={{ initialSortState: { sort: 'requestNumber' } }}
-      ViewComponent={PublicationRequest}
+    <HasCommand
+      commands={shortcuts}
+      isWithinScope={checkScope}
+      scope={document.body}
     >
-      {children}
-    </SASQRoute>
+      <SASQRoute
+        fetchParameters={fetchParameters}
+        FilterComponent={PublicationRequestsFilters}
+        FilterPaneHeaderComponent={renderHeaderComponent}
+        id="publication-requests"
+        mainPaneProps={{
+          appIcon: <AppIcon app="oa" iconKey="app" size="small" />,
+          lastMenu: lastpaneMenu,
+          paneTitle: <FormattedMessage id="ui-oa.publicationRequests" />,
+        }}
+        mclProps={{
+          formatter,
+          columnWidths: { publicationTitle: 500 },
+        }}
+        path={path}
+        resultColumns={resultColumns}
+        sasqProps={{ initialSortState: { sort: 'requestNumber' } }}
+        ViewComponent={PublicationRequest}
+      >
+        {children}
+      </SASQRoute>
+    </HasCommand>
   );
 };
 


### PR DESCRIPTION
Added keyboard shortcuts to OA, this included create/edit controls, saving and expanding/collapsing all accordions. The keyboard shortcut to access the search field has been omitted for the time being as it requires an ID to be correctly focused through the DOM.

Additionally, further work is required for the nested form modals throughout folio as the scope of the shortcuts interferes with these

UIOA-116, UIOA-117