### PR TITLE
chore: Handler stripes registry bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "react-query": "^3.9.0",
     "react-router-dom": "^5.2.0",
     "sinon": "^9.0.2",
-    "@folio/handler-stripes-registry": "^1.0.0"
+    "@folio/handler-stripes-registry": "^1.1.1"
   },
   "dependencies": {
     "@folio/stripes-erm-components": "^6.0.0",
@@ -119,7 +119,7 @@
     "react-final-form-arrays": "^3.1.1"
   },
   "peerDependencies": {
-    "@folio/handler-stripes-registry": "^1.0.0",
+    "@folio/handler-stripes-registry": "^1.1.1",
     "@folio/stripes": "^7.0.0",
     "moment": "^2.22.2",
     "react": "^17.0.2",


### PR DESCRIPTION
Bumped the handler stripes  registry dependency to 1.1.1 in an attempt to fix the issue with the LookUp component not working correctly