### PR TITLE
fix: Agreement link fix

### DIFF
--- a/src/components/PublicationRequestFormSections/LinkAgreementForm/LinkAgreementForm.js
+++ b/src/components/PublicationRequestFormSections/LinkAgreementForm/LinkAgreementForm.js
@@ -79,18 +79,19 @@ const LinkAgreementForm = () => {
         </Col>
       </Row>
       <br />
-      {!values.withoutAgreement && LookupComponent ? (
-        <Field
-          component={LookupComponent}
-          name="agreement.remoteId"
-          onResourceSelected={handleAgreementSelected}
-          resource={agreement}
-        />
-      ) : (
-        <MessageBanner type="error">
-          <FormattedMessage id="ui-oa.publicationRequest.agreementsNotWorking" />
-        </MessageBanner>
-      )}
+      {!values.withoutAgreement &&
+        (LookupComponent ? (
+          <Field
+            component={LookupComponent}
+            name="agreement.remoteId"
+            onResourceSelected={handleAgreementSelected}
+            resource={agreement}
+          />
+        ) : (
+          <MessageBanner type="error">
+            <FormattedMessage id="ui-oa.publicationRequest.agreementsNotWorking" />
+          </MessageBanner>
+        ))}
     </Accordion>
   );
 };


### PR DESCRIPTION
Tweaked the agreement lookup component rendering so that if the request is without an agreement then nothing is rendered, but if an agreement can be linked but the lookup component isnt functioning, then it renders the error message