### PR TITLE
refactor: Constants and useQueryClient

### DIFF
--- a/src/components/PublicationRequestSections/Publication/Publication.js
+++ b/src/components/PublicationRequestSections/Publication/Publication.js
@@ -16,7 +16,7 @@ import {
 } from '@folio/stripes/components';
 import { AppIcon } from '@folio/stripes-core';
 import { JournalDetails, BookDetails } from '../PublicationType';
-import { publicationRequestFields } from '../../../constants';
+import publicationRequestFields from '../../../constants/publicationRequestFields';
 import ExternalLink from '../../ExternalLink';
 import getSortedItems from '../../../util/getSortedItems';
 import urls from '../../../util/urls';

--- a/src/components/views/ChargeForm/ChargeForm.js
+++ b/src/components/views/ChargeForm/ChargeForm.js
@@ -10,7 +10,6 @@ import {
   Paneset,
   PaneMenu,
   IconButton,
-  LoadingView,
   HasCommand,
   checkScope,
   expandAllSections,
@@ -31,14 +30,12 @@ const propTypes = {
     onClose: PropTypes.func.isRequired,
     onSubmit: PropTypes.func.isRequired,
   }).isRequired,
-  isFetching: PropTypes.bool,
   charge: PropTypes.object,
   request: PropTypes.object,
 };
 
 const ChargeForm = ({
   handlers: { onClose, onSubmit },
-  isFetching,
   charge,
   request,
 }) => {
@@ -109,10 +106,6 @@ const ChargeForm = ({
       handler: (e) => collapseAllSections(e, accordionStatusRef),
     },
   ];
-
-  if (isFetching) {
-    return <LoadingView />;
-  }
 
   return (
     <HasCommand

--- a/src/components/views/CorrespondenceForm/CorrespondenceForm.js
+++ b/src/components/views/CorrespondenceForm/CorrespondenceForm.js
@@ -9,7 +9,6 @@ import {
   Paneset,
   PaneMenu,
   IconButton,
-  LoadingView,
   HasCommand,
   checkScope,
 } from '@folio/stripes/components';
@@ -22,13 +21,11 @@ const propTypes = {
     onClose: PropTypes.func.isRequired,
     onSubmit: PropTypes.func.isRequired,
   }).isRequired,
-  isFetching: PropTypes.bool,
   correspondence: PropTypes.object,
 };
 
 const CorrespondenceForm = ({
   handlers: { onClose, onSubmit },
-  isFetching,
   correspondence,
 }) => {
   const { pristine, submitting } = useFormState();
@@ -89,10 +86,6 @@ const CorrespondenceForm = ({
       handler: onSubmit,
     },
   ];
-
-  if (isFetching) {
-    return <LoadingView />;
-  }
 
   return (
     <HasCommand

--- a/src/components/views/CorrespondenceView/CorrespondenceView.js
+++ b/src/components/views/CorrespondenceView/CorrespondenceView.js
@@ -10,7 +10,6 @@ import {
   Button,
   Icon,
   ConfirmationModal,
-  LoadingPane,
 } from '@folio/stripes/components';
 import { AppIcon, IfPermission } from '@folio/stripes/core';
 import { PANE_DEFAULT_WIDTH } from '../../../constants/config';
@@ -19,7 +18,6 @@ const propTypes = {
   onClose: PropTypes.func.isRequired,
   onDelete: PropTypes.func.isRequired,
   onEdit: PropTypes.func.isRequired,
-  isLoading: PropTypes.bool,
   correspondence: PropTypes.object,
 };
 
@@ -27,7 +25,6 @@ const CorrespondenceView = ({
   onClose,
   onDelete,
   onEdit,
-  isLoading,
   correspondence,
 }) => {
   const [showConfirmationModal, setShowConfirmationModal] = useState(false);
@@ -68,16 +65,6 @@ const CorrespondenceView = ({
       </>
     );
   };
-
-  if (isLoading) {
-    return (
-      <LoadingPane
-        defaultWidth={PANE_DEFAULT_WIDTH}
-        dismissible
-        onClose={onClose}
-      />
-    );
-  }
 
   return (
     <Pane

--- a/src/components/views/JournalForm/JournalForm.js
+++ b/src/components/views/JournalForm/JournalForm.js
@@ -9,7 +9,6 @@ import {
   Paneset,
   PaneMenu,
   IconButton,
-  LoadingView,
   HasCommand,
   checkScope,
 } from '@folio/stripes/components';
@@ -22,13 +21,11 @@ const propTypes = {
     onClose: PropTypes.func.isRequired,
     onSubmit: PropTypes.func.isRequired,
   }).isRequired,
-  isLoading: PropTypes.bool,
   journal: PropTypes.object,
 };
 
 const JournalForm = ({
   handlers: { onClose, onSubmit },
-  isLoading,
   journal,
 }) => {
   const { pristine, submitting } = useFormState();
@@ -89,10 +86,6 @@ const JournalForm = ({
       />
     );
   };
-
-  if (isLoading) {
-    return <LoadingView />;
-  }
 
   return (
     <HasCommand

--- a/src/components/views/PartyForm/PartyForm.js
+++ b/src/components/views/PartyForm/PartyForm.js
@@ -9,7 +9,6 @@ import {
   PaneFooter,
   Paneset,
   PaneMenu,
-  LoadingView,
   HasCommand,
   checkScope,
 } from '@folio/stripes/components';
@@ -26,13 +25,12 @@ const propTypes = {
     onClose: PropTypes.func.isRequired,
     onSubmit: PropTypes.func.isRequired,
   }).isRequired,
-  isLoading: PropTypes.bool,
   party: PropTypes.object,
 };
 
 // TODO Replace StreetAddress with StreetAddresses when domain model supports multiple street addresses
 
-const PartyForm = ({ handlers: { onClose, onSubmit }, isLoading, party }) => {
+const PartyForm = ({ handlers: { onClose, onSubmit }, party }) => {
   const { pristine, submitting } = useFormState();
 
   const renderPaneTitle = () => (party ? (
@@ -91,10 +89,6 @@ const PartyForm = ({ handlers: { onClose, onSubmit }, isLoading, party }) => {
       handler: onSubmit,
     },
   ];
-
-  if (isLoading) {
-    return <LoadingView />;
-  }
 
   return (
     <HasCommand

--- a/src/components/views/PublicationRequestForm/PublicationRequestForm.js
+++ b/src/components/views/PublicationRequestForm/PublicationRequestForm.js
@@ -21,7 +21,6 @@ import {
   Paneset,
   PaneMenu,
   Row,
-  LoadingView,
 } from '@folio/stripes/components';
 
 import {
@@ -38,13 +37,11 @@ const propTypes = {
     onClose: PropTypes.func.isRequired,
     onSubmit: PropTypes.func.isRequired,
   }).isRequired,
-  isFetching: PropTypes.bool,
   publicationRequest: PropTypes.object,
 };
 
 const PublicationRequestForm = ({
   handlers: { onClose, onSubmit },
-  isFetching,
   publicationRequest,
 }) => {
   const { values, pristine, submitting } = useFormState();
@@ -128,10 +125,6 @@ const PublicationRequestForm = ({
       </PaneMenu>
     );
   };
-
-  if (isFetching) {
-    return <LoadingView />;
-  }
 
   return (
     <HasCommand

--- a/src/constants/config.js
+++ b/src/constants/config.js
@@ -1,7 +1,3 @@
-const REFDATA_ENDPOINT = 'oa/refdata';
-const SETTINGS_ENDPOINT = 'oa/settings/appSettings';
-export { REFDATA_ENDPOINT, SETTINGS_ENDPOINT };
-
 const PANE_DEFAULT_WIDTH = '50%';
 export { PANE_DEFAULT_WIDTH };
 

--- a/src/constants/endpoints.js
+++ b/src/constants/endpoints.js
@@ -14,3 +14,7 @@ export const WORK_CITATION_ENDPOINT = `${WORKS_ENDPOINT}/citation`;
 export const CORRESPONDENCES_ENDPOINT = 'oa/correspondence';
 export const CORRESPONDENCE_ENDPOINT = (correspondenceId) => `${CORRESPONDENCES_ENDPOINT}/${correspondenceId}`;
 
+export const REFDATA_ENDPOINT = 'oa/refdata';
+export const SETTINGS_ENDPOINT = 'oa/settings/appSettings';
+
+

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -1,5 +1,0 @@
-export { default as publicationRequestFields } from './publicationRequestFields';
-export {
-  REFDATA_ENDPOINT,
-  SETTINGS_ENDPOINT
-} from './config';

--- a/src/routes/CorrespondenceViewRoute/CorrespondenceViewRoute.js
+++ b/src/routes/CorrespondenceViewRoute/CorrespondenceViewRoute.js
@@ -2,20 +2,18 @@ import { useHistory, useParams } from 'react-router-dom';
 import { useOkapiKy } from '@folio/stripes/core';
 import { useQuery, useMutation } from 'react-query';
 
-import { checkScope, HasCommand } from '@folio/stripes/components';
+import { checkScope, HasCommand, LoadingPane } from '@folio/stripes/components';
 import urls from '../../util/urls';
 import CorrespondenceView from '../../components/views/CorrespondenceView';
 import { CORRESPONDENCE_ENDPOINT } from '../../constants/endpoints';
+import { PANE_DEFAULT_WIDTH } from '../../constants/config';
 
 const CorrespondenceViewRoute = () => {
   const history = useHistory();
   const ky = useOkapiKy();
   const { prId, cId } = useParams();
 
-  const { data: correspondence, isLoading } = useQuery(
-    ['ui-oa', 'correspondenceViewRoute', 'correspondence', cId],
-    () => ky(CORRESPONDENCE_ENDPOINT(cId)).json()
-  );
+  const { data: correspondence, isLoading } = useQuery([cId], () => ky(CORRESPONDENCE_ENDPOINT(cId)).json());
 
   const { mutateAsync: deleteCorrespondence } = useMutation(
     ['ui-oa', 'CorrespondenceViewRoute', 'deleteCorrespondence'],
@@ -41,6 +39,16 @@ const CorrespondenceViewRoute = () => {
       handler: () => handleEdit(),
     },
   ];
+
+  if (isLoading) {
+    return (
+      <LoadingPane
+        defaultWidth={PANE_DEFAULT_WIDTH}
+        dismissible
+        onClose={handleClose}
+      />
+    );
+  }
 
   return (
     <HasCommand

--- a/src/settings/index.js
+++ b/src/settings/index.js
@@ -8,7 +8,7 @@ import { useStripes } from '@folio/stripes/core';
 import { useSettings } from '@k-int/stripes-kint-components';
 
 import { PickListValues } from './settingsComponents';
-import { REFDATA_ENDPOINT, SETTINGS_ENDPOINT } from '../constants';
+import { REFDATA_ENDPOINT, SETTINGS_ENDPOINT } from '../constants/endpoints';
 
 const propTypes = {
   resources: PropTypes.shape({

--- a/src/settings/settingsComponents/PickListValues.js
+++ b/src/settings/settingsComponents/PickListValues.js
@@ -5,7 +5,7 @@ import { useHistory } from 'react-router-dom';
 import { Pane, Select } from '@folio/stripes/components';
 import { EditableRefdataList } from '@k-int/stripes-kint-components';
 import useOARefdata from '../../util/useOARefdata';
-import { REFDATA_ENDPOINT } from '../../constants';
+import { REFDATA_ENDPOINT } from '../../constants/endpoints';
 
 const PickListValues = () => {
   const rdcOptions = useOARefdata()?.map((rdv) => ({

--- a/src/util/useOARefdata.js
+++ b/src/util/useOARefdata.js
@@ -1,7 +1,7 @@
 import orderBy from 'lodash/orderBy';
 import { useRefdata, refdataOptions } from '@k-int/stripes-kint-components';
 
-import { REFDATA_ENDPOINT } from '../constants';
+import { REFDATA_ENDPOINT } from '../constants/endpoints';
 
 const useOARefdata = (desc) => {
   const refdata = useRefdata({


### PR DESCRIPTION
Tweaked constants for endpoints for maintenance
Added useQueryClient and invalidateQueries to prevent repeated refetchs and also to solve prior initialValues issues