### PR TITLE
style: Checklist notes

### DIFF
--- a/src/components/Checklist/ChecklistNotes/ChecklistNotes.js
+++ b/src/components/Checklist/ChecklistNotes/ChecklistNotes.js
@@ -50,34 +50,35 @@ const ChecklistNotes = ({ notes, submitNotes, handleDelete }) => {
                   <form onSubmit={handleSubmit}>
                     <div className={css.notesContainer}>
                       <Row middle="xs">
-                        <Col xs={9}>
+                        <Col xs={10}>
                           <Field
                             component={TextArea}
                             fullWidth
                             maxLength={255}
                             name="note"
-                            style={{ height: '110px' }}
+                            style={{ height: '110px', width: '90%' }}
                           />
                         </Col>
-                        <Col xs={3}>
+                        <Col xs={2}>
                           <div>
-                            <Button
-                              key={`save[${note.label}]`}
-                              buttonStyle="primary"
-                              disabled={pristine || submitting}
-                              onClick={() => {
-                                notes[index] = values;
-                                handleSubmit();
-                                setEditing(null);
-                              }}
-                              type="submit"
-                            >
-                              <FormattedMessage id="ui-oa.checklist.save" />
-                            </Button>
-                            {(notes?.length > 1 || note?.id) && (
+                            <Layout className="flex right">
+                              <Button
+                                key={`save[${note.label}]`}
+                                buttonStyle="primary"
+                                disabled={pristine || submitting}
+                                onClick={() => {
+                                  notes[index] = values;
+                                  handleSubmit();
+                                  setEditing(null);
+                                }}
+                                type="submit"
+                              >
+                                <FormattedMessage id="ui-oa.checklist.save" />
+                              </Button>
                               <Button
                                 key={`cancel[${note.label}]`}
                                 data-type-button="cancel"
+                                disabled={notes?.length < 1 || !note?.id}
                                 onClick={() => {
                                   if (note?.id) {
                                     setEditing(false);
@@ -89,7 +90,7 @@ const ChecklistNotes = ({ notes, submitNotes, handleDelete }) => {
                               >
                                 <FormattedMessage id="ui-oa.checklist.cancel" />
                               </Button>
-                            )}
+                            </Layout>
                           </div>
                         </Col>
                       </Row>

--- a/src/components/Checklist/ChecklistNotes/ChecklistNotes.js
+++ b/src/components/Checklist/ChecklistNotes/ChecklistNotes.js
@@ -9,6 +9,7 @@ import {
   IconButton,
   Row,
   TextArea,
+  Layout,
 } from '@folio/stripes/components';
 
 import css from '../Checklist.css';
@@ -103,9 +104,9 @@ const ChecklistNotes = ({ notes, submitNotes, handleDelete }) => {
           <>
             <hr />
             <div className={css.notesContainer}>
-              <Row middle="xs">
-                <Col xs={10}>{note.note}</Col>
-                <Col xs={2}>
+              <Layout className="flex justified">
+                <>{note.note}</>
+                <div>
                   <IconButton
                     disabled={editing}
                     icon="edit"
@@ -116,8 +117,8 @@ const ChecklistNotes = ({ notes, submitNotes, handleDelete }) => {
                     icon="trash"
                     onClick={() => handleDelete(note)}
                   />
-                </Col>
-              </Row>
+                </div>
+              </Layout>
               <br />
               <Row>
                 <Col xs={12}>


### PR DESCRIPTION
Aligned edit/trash icons to right side of notes modal
Tweaked save/cancel button styling to have them be right aligned like the edit/trash icons, aditionally removed conditional rendering of cancel button and replaced with disable prop
