### PR TITLE
UIOA-148: Removed stripes-erm-components from dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,7 +125,6 @@
   },
   "dependencies": {
     "@folio/stripes-acq-components": "^3.1.0",
-    "@folio/stripes-erm-components": "^6.0.0",
     "@k-int/stripes-kint-components": "^2.8.2",
     "classnames": "^2.2.6",
     "compose-function": "^3.0.3",

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "@babel/preset-typescript": "^7.18.6",
     "@folio/eslint-config-stripes": "^6.1.0",
     "@folio/handler-stripes-registry": "^1.1.1",
+    "@folio/stripes-erm-components": "^6.0.0",
     "@folio/service-interaction": "^1.0.0",
     "@folio/stripes": "^7.2.0",
     "@folio/stripes-cli": "^2.6.0",


### PR DESCRIPTION
Fixing a previous commit in which stripes-erm-components should have been in peer dependencies instead of both

[UIOA-148](https://issues.folio.org/browse/UIOA-148)