### PR TITLE
fix: Checklist

### DIFF
--- a/src/components/Checklist/Checklist.js
+++ b/src/components/Checklist/Checklist.js
@@ -130,6 +130,7 @@ const Checklist = ({ onToggle, resource, resourceEndpoint }) => {
       })}
       {notRequiredItems?.length > 0 && (
         <Accordion
+          closedByDefault
           displayWhenClosed={renderBadge()}
           displayWhenOpen={renderBadge()}
           header={NotRequiredHeader}

--- a/src/components/Checklist/ChecklistItem/ChecklistItem.js
+++ b/src/components/Checklist/ChecklistItem/ChecklistItem.js
@@ -11,6 +11,7 @@ import {
   IconButton,
   Headline,
   Layout,
+  Tooltip,
 } from '@folio/stripes/components';
 import { IconSelect } from '@k-int/stripes-kint-components';
 
@@ -139,20 +140,42 @@ const ChecklistItem = ({
                 />
               )}
             </FormattedMessage>
-            <IconButton
-              icon={
-                item?.status?.value === 'not_required'
-                  ? 'eye-open'
-                  : 'eye-closed'
+            <Tooltip
+              id="hide-checklist-item-button-tooltip"
+              text={
+                item?.status?.value === 'not_required' ? (
+                  <FormattedMessage
+                    id="ui-oa.checklist.showItem"
+                    values={{ name: item?.definition?.label }}
+                  />
+                ) : (
+                  <FormattedMessage
+                    id="ui-oa.checklist.hideItem"
+                    values={{ name: item?.definition?.label }}
+                  />
+                )
               }
-              onClick={() => {
-                if (item?.status?.value === 'not_required') {
-                  handleSubmit({ status: 'required' }, item);
-                } else {
-                  handleSubmit({ status: 'not_required' }, item);
-                }
-              }}
-            />
+            >
+              {({ ref, ariaIds }) => (
+                <IconButton
+                  ref={ref}
+                  aria-describedby={ariaIds.sub}
+                  aria-labelledby={ariaIds.text}
+                  icon={
+                    item?.status?.value === 'not_required'
+                      ? 'eye-open'
+                      : 'eye-closed'
+                  }
+                  onClick={() => {
+                    if (item?.status?.value === 'not_required') {
+                      handleSubmit({ status: 'required' }, item);
+                    } else {
+                      handleSubmit({ status: 'not_required' }, item);
+                    }
+                  }}
+                />
+              )}
+            </Tooltip>
           </Col>
         </Row>
       </div>

--- a/src/components/Checklist/ChecklistNotes/ChecklistNotes.js
+++ b/src/components/Checklist/ChecklistNotes/ChecklistNotes.js
@@ -52,6 +52,7 @@ const ChecklistNotes = ({ notes, submitNotes, handleDelete }) => {
                       <Row middle="xs">
                         <Col xs={10}>
                           <Field
+                            autoFocus
                             component={TextArea}
                             fullWidth
                             maxLength={255}

--- a/src/components/Checklist/ChecklistNotes/ChecklistNotes.js
+++ b/src/components/Checklist/ChecklistNotes/ChecklistNotes.js
@@ -17,6 +17,7 @@ import ChecklistMeta from '../ChecklistMeta';
 
 const ChecklistNotes = ({ notes, submitNotes, handleDelete }) => {
   const [editing, setEditing] = useState(false);
+  console.log(notes);
 
   useEffect(() => {
     if (notes?.length < 1) {
@@ -78,7 +79,7 @@ const ChecklistNotes = ({ notes, submitNotes, handleDelete }) => {
                               <Button
                                 key={`cancel[${note.label}]`}
                                 data-type-button="cancel"
-                                disabled={notes?.length < 1 || !note?.id}
+                                disabled={notes?.length <= 1}
                                 onClick={() => {
                                   if (note?.id) {
                                     setEditing(false);

--- a/src/components/Checklist/ChecklistNotes/ChecklistNotes.js
+++ b/src/components/Checklist/ChecklistNotes/ChecklistNotes.js
@@ -105,21 +105,27 @@ const ChecklistNotes = ({ notes, submitNotes, handleDelete }) => {
           <>
             <hr />
             <div className={css.notesContainer}>
-              <Layout className="flex justified">
-                <>{note.note}</>
-                <div>
-                  <IconButton
-                    disabled={editing}
-                    icon="edit"
-                    onClick={() => setEditing(note.id)}
-                  />
-                  <IconButton
-                    disabled={editing}
-                    icon="trash"
-                    onClick={() => handleDelete(note)}
-                  />
-                </div>
-              </Layout>
+              <Row middle="xs">
+                <Col xs={10}>
+                  <>{note.note}</>
+                </Col>
+                <Col xs={2}>
+                  <div>
+                    <Layout className="flex right">
+                      <IconButton
+                        disabled={editing}
+                        icon="edit"
+                        onClick={() => setEditing(note.id)}
+                      />
+                      <IconButton
+                        disabled={editing}
+                        icon="trash"
+                        onClick={() => handleDelete(note)}
+                      />
+                    </Layout>
+                  </div>
+                </Col>
+              </Row>
               <br />
               <Row>
                 <Col xs={12}>

--- a/src/components/Checklist/ChecklistNotes/ChecklistNotes.js
+++ b/src/components/Checklist/ChecklistNotes/ChecklistNotes.js
@@ -17,7 +17,6 @@ import ChecklistMeta from '../ChecklistMeta';
 
 const ChecklistNotes = ({ notes, submitNotes, handleDelete }) => {
   const [editing, setEditing] = useState(false);
-  console.log(notes);
 
   useEffect(() => {
     if (notes?.length < 1) {

--- a/src/components/Checklist/ChecklistNotes/ChecklistNotesModal.js
+++ b/src/components/Checklist/ChecklistNotes/ChecklistNotesModal.js
@@ -27,23 +27,33 @@ const ChecklistNotesModal = ({
     () => ky(resourceEndpoint(ownerId)).json()
   );
 
-  const notes = orderBy(
-    resource?.checklist?.find((element) => element?.id === item?.id)?.notes,
-    'dateCreated',
-    'desc'
-  );
+  const notes =
+    orderBy(
+      resource?.checklist?.find((element) => element?.id === item?.id)?.notes,
+      'dateCreated',
+      'desc'
+    ) || [];
 
   const { mutateAsync: putNotes } = useMutation(
     ['ChecklistNotesModal', 'putNotes'],
     (data) => {
-      ky.put(resourceEndpoint(ownerId), { json: data }).then(() => {
-        queryClient.invalidateQueries([
-          namespace,
-          'notes',
-          'checklistNotesModal',
-          ownerId,
-        ]);
-      });
+      ky.put(resourceEndpoint(ownerId), { json: data })
+        .json()
+        .then((res) => {
+          if (!item?.id) {
+            setSelectedNotesItem(
+              res?.checklist?.find(
+                (e) => e?.definition?.id === item?.definition?.id
+              )
+            );
+          }
+          queryClient.invalidateQueries([
+            namespace,
+            'notes',
+            'checklistNotesModal',
+            ownerId,
+          ]);
+        });
     }
   );
 
@@ -93,7 +103,7 @@ const ChecklistNotesModal = ({
       {!isLoading ? (
         <ChecklistNotes
           handleDelete={handleDelete}
-          notes={notes || []}
+          notes={notes}
           submitNotes={submitNotes}
         />
       ) : (

--- a/src/components/Checklist/ChecklistNotes/ChecklistNotesModal.js
+++ b/src/components/Checklist/ChecklistNotes/ChecklistNotesModal.js
@@ -40,6 +40,8 @@ const ChecklistNotesModal = ({
       ky.put(resourceEndpoint(ownerId), { json: data })
         .json()
         .then((res) => {
+          // If a checklist item hasnt been changed it will note have an associated ID
+          // This check ensures that when a put is made, the selected item is updated with the new ID
           if (!item?.id) {
             setSelectedNotesItem(
               res?.checklist?.find(

--- a/translations/ui-oa/en.json
+++ b/translations/ui-oa/en.json
@@ -385,5 +385,7 @@
   "checklist.outcome.notSet": "Not set",
   "checklist.outcome.other": "Other",
   "checklist.outcome.yes": "Yes",
-  "checklist.outcome.no": "No"
+  "checklist.outcome.no": "No",
+  "checklist.hideItem": "Hide ''{name}'' item",
+  "checklist.showItem": "Show ''{name}'' item"
 }


### PR DESCRIPTION
Fixed cancel button conditional in which it would be disabled even when other notes existed within the modal
Fixed a bug in which creating a new note within an unedited checklist item would result in the note not correctly rendering
Styled not buttons correctly so that large blocks of text for note would not disrupt styling of edit/trash buttons
