### PR TITLE
fix: Charge breakdown MCL

### DIFF
--- a/src/components/ChargeSections/ChargeBreakdown/ChargeBreakdown.js
+++ b/src/components/ChargeSections/ChargeBreakdown/ChargeBreakdown.js
@@ -118,6 +118,7 @@ const ChargeBreakdown = ({ charge }) => {
               ),
             }}
             contentData={breakdownArray}
+            interactive={false}
             visibleColumns={['description', 'chargeAmount', 'localAmount']}
           />
         </Col>


### PR DESCRIPTION
Remove the clickable row action from the "Charge breakdown" MCL

UIOA-173