### PR TITLE
chore: Stripes-kint-components bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
   },
   "dependencies": {
     "@folio/stripes-acq-components": "^3.1.0",
-    "@k-int/stripes-kint-components": "^3.0.1",
+    "@k-int/stripes-kint-components": "^3.0.4",
     "classnames": "^2.2.6",
     "compose-function": "^3.0.3",
     "final-form": "^4.18.5",


### PR DESCRIPTION
Bumped stripes kint components dependency to 3.0.4