### PR TITLE
feat: Multiple/Null report parameters

### DIFF
--- a/src/components/Modals/ReportingModal/ReportingModal.js
+++ b/src/components/Modals/ReportingModal/ReportingModal.js
@@ -33,14 +33,16 @@ const ReportingModal = ({ showModal, setShowModal }) => {
   };
 
   const submitReport = async (values, form) => {
-    const chargeCategories = values?.chargeCategory?.map(e => e.value)?.join(',');
-    const chargeStatuses = values?.chargeStatus?.map(e => e.value)?.join(',');
+    const chargeCategory = values?.chargeCategory
+      ?.map((e) => e.value)
+      ?.join(',');
+    const chargeStatus = values?.chargeStatus?.map((e) => e.value)?.join(',');
 
     const paramMap = {
       institution: values?.institution?.label,
-      paymentPeriod: values?.paymentPeriod || null,
-      chargeCategory: chargeCategories || null,
-      chargeStatus: chargeStatuses || null,
+      ...(!!values?.paymentPeriod && { paymentPeriod: values?.paymentPeriod }),
+      ...(!!chargeCategory && { chargeCategory }),
+      ...(!!chargeStatus && { chargeStatus }),
     };
 
     const queryParams = generateKiwtQueryParams(paramMap, {});

--- a/src/components/Modals/ReportingModal/ReportingModal.js
+++ b/src/components/Modals/ReportingModal/ReportingModal.js
@@ -33,11 +33,14 @@ const ReportingModal = ({ showModal, setShowModal }) => {
   };
 
   const submitReport = async (values, form) => {
+    const chargeCategories = values?.chargeCategory?.map(e => e.value)?.join(',');
+    const chargeStatuses = values?.chargeStatus?.map(e => e.value)?.join(',');
+
     const paramMap = {
       institution: values?.institution?.label,
-      paymentPeriod: values?.paymentPeriod,
-      chargeCategory: values?.chargeCategory,
-      chargeStatus: values?.chargeStatus,
+      paymentPeriod: values?.paymentPeriod || null,
+      chargeCategory: chargeCategories || null,
+      chargeStatus: chargeStatuses || null,
     };
 
     const queryParams = generateKiwtQueryParams(paramMap, {});

--- a/src/components/Modals/ReportingModal/ReportingModal.js
+++ b/src/components/Modals/ReportingModal/ReportingModal.js
@@ -26,16 +26,14 @@ const ReportingModal = ({ showModal, setShowModal }) => {
     const url = window.URL.createObjectURL(blob);
     const a = document.createElement('a');
     a.href = url;
-    a.download = `${values?.paymentPeriod}_${values?.institution?.value}_${values?.reportFormat}.csv`;
+    a.download = `${values.paymentPeriod ? values?.paymentPeriod + '_' : ''}${values?.institution?.value}_${values?.reportFormat}.csv`;
     document.body.appendChild(a);
     a.click();
     a.remove();
   };
 
   const submitReport = async (values, form) => {
-    const chargeCategory = values?.chargeCategory
-      ?.map((e) => e.value)
-      ?.join(',');
+    const chargeCategory = values?.chargeCategory?.map((e) => e.value)?.join(',');
     const chargeStatus = values?.chargeStatus?.map((e) => e.value)?.join(',');
 
     const paramMap = {

--- a/src/components/ReportingFormSections/ReportingInfoForm/ReportingInfoForm.js
+++ b/src/components/ReportingFormSections/ReportingInfoForm/ReportingInfoForm.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import { Col, Label, Row, Select, TextField } from '@folio/stripes/components';
+import { Col, Label, MultiSelection, Row, Select, TextField } from '@folio/stripes/components';
 import { Field } from 'react-final-form';
 import { FormattedMessage } from 'react-intl';
 import { requiredValidator } from '@folio/stripes-erm-components';
@@ -63,16 +63,16 @@ const ReportingInfoForm = ({ institution }) => {
       <Row>
         <Col xs={6}>
           <Field
-            component={Select}
-            dataOptions={[{ value: '', label: '' }, ...chargeCategoriesValues]}
+            component={MultiSelection}
+            dataOptions={[...chargeCategoriesValues]}
             label={<FormattedMessage id="ui-oa.report.chargeCategories" />}
             name="chargeCategory"
           />
         </Col>
         <Col xs={6}>
           <Field
-            component={Select}
-            dataOptions={[{ value: '', label: '' }, ...chargeStatusesValues]}
+            component={MultiSelection}
+            dataOptions={[...chargeStatusesValues]}
             label={<FormattedMessage id="ui-oa.report.chargeStatuses" />}
             name="chargeStatus"
           />


### PR DESCRIPTION
Added support so that multiple charge categories/statuses can be added to the query parameters, additionally added conditionals so that if no payment period, charge categories or statuses are supplied, they will not be included in query parameters

[UIOA-131](https://issues.folio.org/browse/UIOA-131)