### PR TITLE
fix: Sentence case title

### DIFF
--- a/translations/ui-oa/en.json
+++ b/translations/ui-oa/en.json
@@ -1,5 +1,5 @@
 {
-  "meta.title": "Open Access",
+  "meta.title": "Open access",
 
   "appMenu.keyboardShortcuts": "Keyboards shortcuts",
   "edit": "Edit",

--- a/translations/ui-oa/en_US.json
+++ b/translations/ui-oa/en_US.json
@@ -1,5 +1,5 @@
 {
-    "meta.title": "Open Access",
+    "meta.title": "Open access",
     "settings.edit": "Edit",
     "settings.finish-editing": "Save",
     "settingName.settingLoading": "Loading",


### PR DESCRIPTION
Changed all associated OA titles to sentence case, from "Open Access" to "Open access"

[UIOA-180](https://issues.folio.org/browse/UIOA-180)