### PR TITLE
chore: Refdata permissions

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,8 @@
           "oa.correspondence.view",
           "oa.party.view",
           "oa.charges.view",
-          "oa.checklistItems.view"
+          "oa.checklistItems.view",
+          "oa.refdata.read"
         ],
         "visible": true
       },
@@ -113,7 +114,8 @@
           "oa.correspondence.manage",
           "oa.party.manage",
           "oa.charges.manage",
-          "oa.checklistItems.manage"
+          "oa.checklistItems.manage",
+          "oa.refdata.read"
         ],
         "visible": true
       }


### PR DESCRIPTION
To allow the user to access the relevant refdata, oa.refdata.read  permission is now included in the  ui-oa.oa.manage and ui-oa.oa.view permission sets

[UIOA-183](https://issues.folio.org/browse/UIOA-183)