### PR TITLE
test: erm testing

### DIFF
--- a/__mocks__/@folio/stripes-components.js
+++ b/__mocks__/@folio/stripes-components.js
@@ -1,0 +1,9 @@
+import { mockStripesIcon } from '@folio/stripes-erm-testing/jest/mocks';
+
+jest.mock('@folio/stripes-components/lib/Icon', () => mockStripesIcon);
+
+module.exports = {
+  ...jest.requireActual('@folio/stripes-components'),
+  Icon: mockStripesIcon
+};
+

--- a/__mocks__/@folio/stripes/core.js
+++ b/__mocks__/@folio/stripes/core.js
@@ -1,0 +1,6 @@
+import { mockStripesCore } from '@folio/stripes-erm-testing/jest/mocks';
+
+module.exports = {
+  ...jest.requireActual('@folio/stripes-core'),
+  ...mockStripesCore
+};

--- a/__mocks__/@folio/stripes/smart-components.js
+++ b/__mocks__/@folio/stripes/smart-components.js
@@ -1,0 +1,6 @@
+import { mockStripesSmartComponents } from '@folio/stripes-erm-testing/jest/mocks';
+
+module.exports = {
+  ...jest.requireActual('@folio/stripes/smart-components'),
+  ...mockStripesSmartComponents
+};

--- a/__mocks__/@k-int/stripes-kint-components.js
+++ b/__mocks__/@k-int/stripes-kint-components.js
@@ -1,0 +1,6 @@
+import { mockKintComponents } from '@folio/stripes-erm-testing/jest/mocks';
+
+module.exports = {
+  ...jest.requireActual('@k-int/stripes-kint-components'),
+  ...mockKintComponents,
+};

--- a/__mocks__/currency-codes/data.js
+++ b/__mocks__/currency-codes/data.js
@@ -1,0 +1,4 @@
+//FIXME currently since erm-testing exports TestForm using stripes-components, we have an issue
+import { mockCurrencyData } from '@folio/stripes-erm-testing/jest/mocks';
+
+module.exports = mockCurrencyData;

--- a/__mocks__/currency-codes/data.js
+++ b/__mocks__/currency-codes/data.js
@@ -1,4 +1,4 @@
-//FIXME currently since erm-testing exports TestForm using stripes-components, we have an issue
+// FIXME currently since erm-testing exports TestForm using stripes-components, we have an issue
 import { mockCurrencyData } from '@folio/stripes-erm-testing/jest/mocks';
 
 module.exports = mockCurrencyData;

--- a/__mocks__/react-query.js
+++ b/__mocks__/react-query.js
@@ -1,0 +1,6 @@
+import { mockReactQuery } from '@folio/stripes-erm-testing/jest/mocks';
+
+module.exports = {
+  ...jest.requireActual('react-query'),
+  ...mockReactQuery
+};

--- a/__mocks__/react-router-dom.js
+++ b/__mocks__/react-router-dom.js
@@ -1,0 +1,7 @@
+//FIXME currently since erm-testing exports TestForm using stripes-components, we have an issue
+import { mockReactRouterDom } from '@folio/stripes-erm-testing/jest/mocks';
+
+module.exports = {
+  ...jest.requireActual('react-router-dom'),
+  ...mockReactRouterDom
+};

--- a/__mocks__/react-router-dom.js
+++ b/__mocks__/react-router-dom.js
@@ -1,4 +1,4 @@
-//FIXME currently since erm-testing exports TestForm using stripes-components, we have an issue
+// FIXME currently since erm-testing exports TestForm using stripes-components, we have an issue
 import { mockReactRouterDom } from '@folio/stripes-erm-testing/jest/mocks';
 
 module.exports = {

--- a/__mocks__/stripes-config.js
+++ b/__mocks__/stripes-config.js
@@ -1,0 +1,3 @@
+import { mockStripesConfig } from '@folio/stripes-erm-testing/jest/mocks';
+
+module.exports = mockStripesConfig;

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,4 @@
-const jestConf = require('@folio/stripes-erm-components/jest.config');
+const jestConf = require('@folio/stripes-erm-testing/jest.config');
 const path = require('path');
 
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -135,6 +135,7 @@
     "@folio/eslint-config-stripes": "^6.1.0",
     "@folio/handler-stripes-registry": "^1.1.1",
     "@folio/stripes-erm-components": "^7.0.0",
+    "@folio/stripes-erm-testing": "^1.0.0",
     "@folio/service-interaction": "^1.0.0",
     "@folio/stripes": "^7.2.0",
     "@folio/stripes-cli": "^2.6.0",
@@ -172,7 +173,7 @@
   },
   "dependencies": {
     "@folio/stripes-acq-components": "^3.1.0",
-    "@k-int/stripes-kint-components": "^3.0.4",
+    "@k-int/stripes-kint-components": "^3.1.0",
     "classnames": "^2.2.6",
     "compose-function": "^3.0.3",
     "final-form": "^4.18.5",

--- a/src/components/CorrespondenceFormSections/CorrespondenceInfoForm/CorrespondenceInfoForm.test.js
+++ b/src/components/CorrespondenceFormSections/CorrespondenceInfoForm/CorrespondenceInfoForm.test.js
@@ -1,4 +1,3 @@
-import '@folio/stripes-erm-components/test/jest/__mock__';
 import {
   renderWithIntl,
   TestForm,

--- a/src/components/CorrespondenceFormSections/CorrespondenceInfoForm/CorrespondenceInfoForm.test.js
+++ b/src/components/CorrespondenceFormSections/CorrespondenceInfoForm/CorrespondenceInfoForm.test.js
@@ -1,7 +1,7 @@
 import {
   renderWithIntl,
   TestForm,
-} from '@folio/stripes-erm-components/test/jest/helpers';
+} from '@folio/stripes-erm-testing';
 import { Datepicker, Select, TextArea, TextField } from '@folio/stripes-testing';
 import { translationsProperties } from '../../../../test/helpers';
 import CorrespondenceInfoForm from './CorrespondenceInfoForm';

--- a/src/components/JournalSections/JournalInstances/JournalInstances.test.js
+++ b/src/components/JournalSections/JournalInstances/JournalInstances.test.js
@@ -1,5 +1,5 @@
-import '@folio/stripes-erm-components/test/jest/__mock__';
-import { renderWithIntl } from '@folio/stripes-erm-components/test/jest/helpers';
+
+import { renderWithIntl } from '@folio/stripes-erm-testing';
 import { within } from '@testing-library/react';
 import { translationsProperties } from '../../../../test/helpers';
 import JournalInstances from './JournalInstances';

--- a/src/components/PartyFormSections/AffiliationForm/AffiliationForm.test.js
+++ b/src/components/PartyFormSections/AffiliationForm/AffiliationForm.test.js
@@ -1,4 +1,4 @@
-import '@folio/stripes-erm-components/test/jest/__mock__';
+
 import {
   renderWithIntl,
   TestForm,

--- a/src/components/PartyFormSections/AffiliationForm/AffiliationForm.test.js
+++ b/src/components/PartyFormSections/AffiliationForm/AffiliationForm.test.js
@@ -2,7 +2,7 @@
 import {
   renderWithIntl,
   TestForm,
-} from '@folio/stripes-erm-components/test/jest/helpers';
+} from '@folio/stripes-erm-testing';
 import { translationsProperties } from '../../../../test/helpers';
 import AffiliationForm from './AffiliationForm';
 import {

--- a/src/components/PartyFormSections/PartyInfoForm/PartyInfoForm.test.js
+++ b/src/components/PartyFormSections/PartyInfoForm/PartyInfoForm.test.js
@@ -1,5 +1,5 @@
-import '@folio/stripes-erm-components/test/jest/__mock__';
-import { renderWithIntl, TestForm } from '@folio/stripes-erm-components/test/jest/helpers';
+
+import { renderWithIntl, TestForm } from '@folio/stripes-erm-testing';
 import { translationsProperties } from '../../../../test/helpers';
 import PartyInfoForm from './PartyInfoForm';
 import { party, partyHandlers as handlers } from '../../../../test/resources';

--- a/src/components/PartySections/PartyInfo/PartyInfo.test.js
+++ b/src/components/PartySections/PartyInfo/PartyInfo.test.js
@@ -1,5 +1,6 @@
-import '@folio/stripes-erm-components/test/jest/__mock__';
-import { renderWithIntl } from '@folio/stripes-erm-components/test/jest/helpers';
+import '@folio/stripes-erm-testing/jest/directMocks';
+import { renderWithIntl } from '@folio/stripes-erm-testing';
+
 import { KeyValue } from '@folio/stripes-testing';
 import { MemoryRouter } from 'react-router-dom';
 import { translationsProperties } from '../../../../test/helpers';

--- a/src/components/PartySections/PartyInfo/PartyInfo.test.js
+++ b/src/components/PartySections/PartyInfo/PartyInfo.test.js
@@ -1,9 +1,9 @@
-import '@folio/stripes-erm-testing/jest/directMocks';
 import { renderWithIntl } from '@folio/stripes-erm-testing';
 
 import { KeyValue } from '@folio/stripes-testing';
 import { MemoryRouter } from 'react-router-dom';
 import { translationsProperties } from '../../../../test/helpers';
+
 import PartyInfo from './PartyInfo';
 import { party } from '../../../../test/resources';
 

--- a/src/components/PublicationRequestFormSections/FieldArrays/ExternalRequestIdFieldArray/ExternalRequestIdFieldArray.test.js
+++ b/src/components/PublicationRequestFormSections/FieldArrays/ExternalRequestIdFieldArray/ExternalRequestIdFieldArray.test.js
@@ -3,7 +3,7 @@ import React from 'react';
 import {
   renderWithIntl,
   TestForm,
-} from '@folio/stripes-erm-components/test/jest/helpers';
+} from '@folio/stripes-erm-testing';
 import { within } from '@testing-library/react';
 import { Button } from '@folio/stripes-testing';
 import {

--- a/src/components/PublicationRequestFormSections/FieldArrays/ExternalRequestIdFieldArray/ExternalRequestIdFieldArray.test.js
+++ b/src/components/PublicationRequestFormSections/FieldArrays/ExternalRequestIdFieldArray/ExternalRequestIdFieldArray.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import '@folio/stripes-erm-components/test/jest/__mock__';
+
 import {
   renderWithIntl,
   TestForm,

--- a/src/components/PublicationRequestFormSections/FieldArrays/FundingFieldArray/FundingFieldArray.test.js
+++ b/src/components/PublicationRequestFormSections/FieldArrays/FundingFieldArray/FundingFieldArray.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import '@folio/stripes-erm-components/test/jest/__mock__';
+
 import {
   renderWithIntl,
   TestForm,

--- a/src/components/PublicationRequestFormSections/FieldArrays/FundingFieldArray/FundingFieldArray.test.js
+++ b/src/components/PublicationRequestFormSections/FieldArrays/FundingFieldArray/FundingFieldArray.test.js
@@ -3,7 +3,7 @@ import React from 'react';
 import {
   renderWithIntl,
   TestForm,
-} from '@folio/stripes-erm-components/test/jest/helpers';
+} from '@folio/stripes-erm-testing';
 import { Button } from '@folio/stripes-testing';
 
 import FundingFieldArray from './FundingFieldArray';

--- a/src/components/PublicationRequestFormSections/FieldArrays/IdentifiersFieldArray/IdentifiersFieldArray.test.js
+++ b/src/components/PublicationRequestFormSections/FieldArrays/IdentifiersFieldArray/IdentifiersFieldArray.test.js
@@ -3,7 +3,7 @@ import React from 'react';
 import {
   renderWithIntl,
   TestForm,
-} from '@folio/stripes-erm-components/test/jest/helpers';
+} from '@folio/stripes-erm-testing';
 import { Button } from '@folio/stripes-testing';
 
 import IdentifiersFieldArray from './IdentifiersFieldArray';

--- a/src/components/PublicationRequestFormSections/FieldArrays/IdentifiersFieldArray/IdentifiersFieldArray.test.js
+++ b/src/components/PublicationRequestFormSections/FieldArrays/IdentifiersFieldArray/IdentifiersFieldArray.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import '@folio/stripes-erm-components/test/jest/__mock__';
+
 import {
   renderWithIntl,
   TestForm,

--- a/src/components/PublicationRequestFormSections/FieldArrays/PublicationStatusFieldArray/PublicationStatusFieldArray.test.js
+++ b/src/components/PublicationRequestFormSections/FieldArrays/PublicationStatusFieldArray/PublicationStatusFieldArray.test.js
@@ -3,7 +3,7 @@ import React from 'react';
 import {
   renderWithIntl,
   TestForm,
-} from '@folio/stripes-erm-components/test/jest/helpers';
+} from '@folio/stripes-erm-testing';
 import { Button } from '@folio/stripes-testing';
 
 import PublicationStatusFieldArray from './PublicationStatusFieldArray';

--- a/src/components/PublicationRequestFormSections/FieldArrays/PublicationStatusFieldArray/PublicationStatusFieldArray.test.js
+++ b/src/components/PublicationRequestFormSections/FieldArrays/PublicationStatusFieldArray/PublicationStatusFieldArray.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import '@folio/stripes-erm-components/test/jest/__mock__';
+
 import {
   renderWithIntl,
   TestForm,

--- a/src/components/PublicationRequestFormSections/FundingForm/FundingForm.test.js
+++ b/src/components/PublicationRequestFormSections/FundingForm/FundingForm.test.js
@@ -1,5 +1,5 @@
-import '@folio/stripes-erm-components/test/jest/__mock__';
-import { renderWithIntl } from '@folio/stripes-erm-components/test/jest/helpers';
+
+import { renderWithIntl } from '@folio/stripes-erm-testing';
 import { Accordion } from '@folio/stripes-testing';
 import { translationsProperties } from '../../../../test/helpers';
 import FundingForm from './FundingForm';

--- a/src/components/PublicationRequestFormSections/PublicationForm/PublicationBook/PublicationBook.test.js
+++ b/src/components/PublicationRequestFormSections/PublicationForm/PublicationBook/PublicationBook.test.js
@@ -2,7 +2,7 @@
 import {
   renderWithIntl,
   TestForm,
-} from '@folio/stripes-erm-components/test/jest/helpers';
+} from '@folio/stripes-erm-testing';
 import { book, bookHandlers as handlers } from '../../../../../test/resources';
 import { translationsProperties } from '../../../../../test/helpers';
 import PublicationBook from './PublicationBook';

--- a/src/components/PublicationRequestFormSections/PublicationForm/PublicationBook/PublicationBook.test.js
+++ b/src/components/PublicationRequestFormSections/PublicationForm/PublicationBook/PublicationBook.test.js
@@ -1,4 +1,4 @@
-import '@folio/stripes-erm-components/test/jest/__mock__';
+
 import {
   renderWithIntl,
   TestForm,

--- a/src/components/PublicationRequestFormSections/PublicationStatusForm/PublicationStatusForm.test.js
+++ b/src/components/PublicationRequestFormSections/PublicationStatusForm/PublicationStatusForm.test.js
@@ -1,5 +1,5 @@
-import '@folio/stripes-erm-components/test/jest/__mock__';
-import { renderWithIntl } from '@folio/stripes-erm-components/test/jest/helpers';
+
+import { renderWithIntl } from '@folio/stripes-erm-testing';
 import { Accordion } from '@folio/stripes-testing';
 import { translationsProperties } from '../../../../test/helpers';
 import PublicationStatusForm from './PublicationStatusForm';

--- a/src/components/PublicationRequestFormSections/RequestInfoForm/RequestInfoForm.test.js
+++ b/src/components/PublicationRequestFormSections/RequestInfoForm/RequestInfoForm.test.js
@@ -1,5 +1,5 @@
-import '@folio/stripes-erm-components/test/jest/__mock__';
-import { renderWithIntl, TestForm } from '@folio/stripes-erm-components/test/jest/helpers';
+
+import { renderWithIntl, TestForm } from '@folio/stripes-erm-testing';
 import { Datepicker, Select, KeyValue } from '@folio/stripes-testing';
 import { translationsProperties } from '../../../../test/helpers';
 import RequestInfoForm from './RequestInfoForm';

--- a/src/components/PublicationRequestSections/Agreement/Agreement.test.js
+++ b/src/components/PublicationRequestSections/Agreement/Agreement.test.js
@@ -1,5 +1,5 @@
-import '@folio/stripes-erm-components/test/jest/__mock__';
-import { renderWithIntl } from '@folio/stripes-erm-components/test/jest/helpers';
+
+import { renderWithIntl } from '@folio/stripes-erm-testing';
 import { Accordion, KeyValue } from '@folio/stripes-testing';
 import { translationsProperties } from '../../../../test/helpers';
 import Agreement from './Agreement';

--- a/src/components/PublicationRequestSections/Correspondence/Correspondence.test.js
+++ b/src/components/PublicationRequestSections/Correspondence/Correspondence.test.js
@@ -1,5 +1,5 @@
-import '@folio/stripes-erm-components/test/jest/__mock__';
-import { renderWithIntl } from '@folio/stripes-erm-components/test/jest/helpers';
+
+import { renderWithIntl } from '@folio/stripes-erm-testing';
 import {
   Accordion,
   MultiColumnList,

--- a/src/components/PublicationRequestSections/CorrespondingAuthor/CorrespondingAuthor.test.js
+++ b/src/components/PublicationRequestSections/CorrespondingAuthor/CorrespondingAuthor.test.js
@@ -1,5 +1,5 @@
-import '@folio/stripes-erm-components/test/jest/__mock__';
-import { renderWithIntl } from '@folio/stripes-erm-components/test/jest/helpers';
+
+import { renderWithIntl } from '@folio/stripes-erm-testing';
 import { Accordion } from '@folio/stripes-testing';
 import { MemoryRouter } from 'react-router-dom';
 import { translationsProperties } from '../../../../test/helpers';

--- a/src/components/PublicationRequestSections/Funding/Funding.test.js
+++ b/src/components/PublicationRequestSections/Funding/Funding.test.js
@@ -1,5 +1,5 @@
-import '@folio/stripes-erm-components/test/jest/__mock__';
-import { renderWithIntl } from '@folio/stripes-erm-components/test/jest/helpers';
+
+import { renderWithIntl } from '@folio/stripes-erm-testing';
 import {
   Accordion,
   MultiColumnList,

--- a/src/components/PublicationRequestSections/Publication/Publication.test.js
+++ b/src/components/PublicationRequestSections/Publication/Publication.test.js
@@ -1,5 +1,5 @@
-import '@folio/stripes-erm-components/test/jest/__mock__';
-import { renderWithIntl } from '@folio/stripes-erm-components/test/jest/helpers';
+
+import { renderWithIntl } from '@folio/stripes-erm-testing';
 import {
   Accordion,
   MultiColumnList,

--- a/src/components/PublicationRequestSections/PublicationStatus/PublicationStatus.test.js
+++ b/src/components/PublicationRequestSections/PublicationStatus/PublicationStatus.test.js
@@ -1,5 +1,5 @@
-import '@folio/stripes-erm-components/test/jest/__mock__';
-import { renderWithIntl } from '@folio/stripes-erm-components/test/jest/helpers';
+
+import { renderWithIntl } from '@folio/stripes-erm-testing';
 import {
   Accordion,
   MultiColumnList,

--- a/src/components/PublicationRequestSections/PublicationType/BookDetails/BookDetails.test.js
+++ b/src/components/PublicationRequestSections/PublicationType/BookDetails/BookDetails.test.js
@@ -1,5 +1,5 @@
-import '@folio/stripes-erm-components/test/jest/__mock__';
-import { renderWithIntl } from '@folio/stripes-erm-components/test/jest/helpers';
+
+import { renderWithIntl } from '@folio/stripes-erm-testing';
 import { KeyValue } from '@folio/stripes-testing';
 import { translationsProperties } from '../../../../../test/helpers';
 import BookDetails from './BookDetails';

--- a/src/components/PublicationRequestSections/PublicationType/JournalDetails/JournalDetails.test.js
+++ b/src/components/PublicationRequestSections/PublicationType/JournalDetails/JournalDetails.test.js
@@ -1,5 +1,5 @@
-import '@folio/stripes-erm-components/test/jest/__mock__';
-import { renderWithIntl } from '@folio/stripes-erm-components/test/jest/helpers';
+
+import { renderWithIntl } from '@folio/stripes-erm-testing';
 import { KeyValue } from '@folio/stripes-testing';
 import { translationsProperties } from '../../../../../test/helpers';
 import JournalDetails from './JournalDetails';

--- a/src/components/PublicationRequestSections/RequestContact/RequestContact.test.js
+++ b/src/components/PublicationRequestSections/RequestContact/RequestContact.test.js
@@ -1,5 +1,5 @@
-import '@folio/stripes-erm-components/test/jest/__mock__';
-import { renderWithIntl } from '@folio/stripes-erm-components/test/jest/helpers';
+
+import { renderWithIntl } from '@folio/stripes-erm-testing';
 import { Accordion } from '@folio/stripes-testing';
 import { MemoryRouter } from 'react-router-dom';
 import RequestContact from './RequestContact';

--- a/src/components/PublicationRequestSections/RequestInfo/RequestInfo.test.js
+++ b/src/components/PublicationRequestSections/RequestInfo/RequestInfo.test.js
@@ -1,5 +1,5 @@
-import '@folio/stripes-erm-components/test/jest/__mock__';
-import { renderWithIntl } from '@folio/stripes-erm-components/test/jest/helpers';
+
+import { renderWithIntl } from '@folio/stripes-erm-testing';
 import { KeyValue } from '@folio/stripes-testing';
 import RequestInfo from './RequestInfo';
 

--- a/src/components/views/ChargeForm/ChargeForm.test.js
+++ b/src/components/views/ChargeForm/ChargeForm.test.js
@@ -2,7 +2,7 @@
 import {
   renderWithIntl,
   TestForm,
-} from '@folio/stripes-erm-components/test/jest/helpers';
+} from '@folio/stripes-erm-testing';
 import { Button } from '@folio/stripes-testing';
 import { translationsProperties } from '../../../../test/helpers';
 import ChargeForm from './ChargeForm';

--- a/src/components/views/ChargeForm/ChargeForm.test.js
+++ b/src/components/views/ChargeForm/ChargeForm.test.js
@@ -1,4 +1,4 @@
-import '@folio/stripes-erm-components/test/jest/__mock__';
+
 import {
   renderWithIntl,
   TestForm,

--- a/src/components/views/CorrespondenceForm/CorrespondenceForm.test.js
+++ b/src/components/views/CorrespondenceForm/CorrespondenceForm.test.js
@@ -1,4 +1,4 @@
-import '@folio/stripes-erm-components/test/jest/__mock__';
+
 import {
   renderWithIntl,
   TestForm,

--- a/src/components/views/CorrespondenceForm/CorrespondenceForm.test.js
+++ b/src/components/views/CorrespondenceForm/CorrespondenceForm.test.js
@@ -2,7 +2,7 @@
 import {
   renderWithIntl,
   TestForm,
-} from '@folio/stripes-erm-components/test/jest/helpers';
+} from '@folio/stripes-erm-testing';
 import { Button } from '@folio/stripes-testing';
 import { translationsProperties } from '../../../../test/helpers';
 import CorrespondenceForm from './CorrespondenceForm';

--- a/src/components/views/CorrespondenceView/CorrespondenceView.test.js
+++ b/src/components/views/CorrespondenceView/CorrespondenceView.test.js
@@ -1,5 +1,5 @@
-import '@folio/stripes-erm-components/test/jest/__mock__';
-import { renderWithIntl } from '@folio/stripes-erm-components/test/jest/helpers';
+
+import { renderWithIntl } from '@folio/stripes-erm-testing';
 import { KeyValue, Button, Modal } from '@folio/stripes-testing';
 import { translationsProperties } from '../../../../test/helpers';
 import CorrespondenceView from './CorrespondenceView';

--- a/src/components/views/Journal/Journal.test.js
+++ b/src/components/views/Journal/Journal.test.js
@@ -1,5 +1,5 @@
-import '@folio/stripes-erm-components/test/jest/__mock__';
-import { renderWithIntl } from '@folio/stripes-erm-components/test/jest/helpers';
+
+import { renderWithIntl } from '@folio/stripes-erm-testing';
 import { MemoryRouter } from 'react-router-dom';
 import { translationsProperties } from '../../../../test/helpers';
 import Journal from './Journal';

--- a/src/components/views/Party/Party.test.js
+++ b/src/components/views/Party/Party.test.js
@@ -1,6 +1,4 @@
-import '@folio/stripes-erm-components/test/jest/__mock__';
-
-import { renderWithIntl } from '@folio/stripes-erm-components/test/jest/helpers';
+import { renderWithIntl } from '@folio/stripes-erm-testing';
 
 import translationsProperties from '../../../../test/helpers/translationsProperties';
 import Party from './Party';

--- a/src/components/views/PartyForm/PartyForm.test.js
+++ b/src/components/views/PartyForm/PartyForm.test.js
@@ -1,4 +1,4 @@
-import '@folio/stripes-erm-components/test/jest/__mock__';
+
 import {
   renderWithIntl,
   TestForm,

--- a/src/components/views/PartyForm/PartyForm.test.js
+++ b/src/components/views/PartyForm/PartyForm.test.js
@@ -2,7 +2,7 @@
 import {
   renderWithIntl,
   TestForm,
-} from '@folio/stripes-erm-components/test/jest/helpers';
+} from '@folio/stripes-erm-testing';
 import { Button } from '@folio/stripes-testing';
 import { translationsProperties } from '../../../../test/helpers';
 import PartyForm from './PartyForm';

--- a/src/components/views/PublicationRequest/PublicationRequest.test.js
+++ b/src/components/views/PublicationRequest/PublicationRequest.test.js
@@ -1,5 +1,5 @@
-import '@folio/stripes-erm-components/test/jest/__mock__';
-import { renderWithIntl } from '@folio/stripes-erm-components/test/jest/helpers';
+
+import { renderWithIntl } from '@folio/stripes-erm-testing';
 import { MemoryRouter } from 'react-router-dom';
 import { translationsProperties } from '../../../../test/helpers';
 import PublicationRequest from './PublicationRequest';

--- a/src/routes/ChargeCreateRoute/ChargeCreateRoute.test.js
+++ b/src/routes/ChargeCreateRoute/ChargeCreateRoute.test.js
@@ -1,5 +1,5 @@
 
-import { renderWithIntl } from '@folio/stripes-erm-components';
+import { renderWithIntl } from '@folio/stripes-erm-testing';
 import ChargeCreateRoute from './ChargeCreateRoute';
 import { translationsProperties } from '../../../test/helpers';
 

--- a/src/routes/ChargeCreateRoute/ChargeCreateRoute.test.js
+++ b/src/routes/ChargeCreateRoute/ChargeCreateRoute.test.js
@@ -1,4 +1,4 @@
-import '@folio/stripes-erm-components/test/jest/__mock__';
+
 import { renderWithIntl } from '@folio/stripes-erm-components';
 import ChargeCreateRoute from './ChargeCreateRoute';
 import { translationsProperties } from '../../../test/helpers';

--- a/src/routes/ChargeEditRoute/ChargeEditRoute.test.js
+++ b/src/routes/ChargeEditRoute/ChargeEditRoute.test.js
@@ -1,5 +1,5 @@
 
-import { renderWithIntl } from '@folio/stripes-erm-components';
+import { renderWithIntl } from '@folio/stripes-erm-testing';
 import ChargeEditRoute from './ChargeEditRoute';
 import { translationsProperties } from '../../../test/helpers';
 

--- a/src/routes/ChargeEditRoute/ChargeEditRoute.test.js
+++ b/src/routes/ChargeEditRoute/ChargeEditRoute.test.js
@@ -1,4 +1,4 @@
-import '@folio/stripes-erm-components/test/jest/__mock__';
+
 import { renderWithIntl } from '@folio/stripes-erm-components';
 import ChargeEditRoute from './ChargeEditRoute';
 import { translationsProperties } from '../../../test/helpers';

--- a/src/routes/ChargeViewRoute/ChargeViewRoute.test.js
+++ b/src/routes/ChargeViewRoute/ChargeViewRoute.test.js
@@ -1,5 +1,5 @@
 
-import { renderWithIntl } from '@folio/stripes-erm-components';
+import { renderWithIntl } from '@folio/stripes-erm-testing';
 
 import ChargeViewRoute from './ChargeViewRoute';
 import { translationsProperties } from '../../../test/helpers';

--- a/src/routes/ChargeViewRoute/ChargeViewRoute.test.js
+++ b/src/routes/ChargeViewRoute/ChargeViewRoute.test.js
@@ -1,4 +1,4 @@
-import '@folio/stripes-erm-components/test/jest/__mock__';
+
 import { renderWithIntl } from '@folio/stripes-erm-components';
 
 import ChargeViewRoute from './ChargeViewRoute';

--- a/src/routes/CorrespondenceCreateRoute/CorrespondenceCreateRoute.test.js
+++ b/src/routes/CorrespondenceCreateRoute/CorrespondenceCreateRoute.test.js
@@ -1,4 +1,4 @@
-import '@folio/stripes-erm-components/test/jest/__mock__';
+
 import { renderWithIntl } from '@folio/stripes-erm-components';
 
 import CorrespondenceCreateRoute from './CorrespondenceCreateRoute';

--- a/src/routes/CorrespondenceCreateRoute/CorrespondenceCreateRoute.test.js
+++ b/src/routes/CorrespondenceCreateRoute/CorrespondenceCreateRoute.test.js
@@ -1,5 +1,5 @@
 
-import { renderWithIntl } from '@folio/stripes-erm-components';
+import { renderWithIntl } from '@folio/stripes-erm-testing';
 
 import CorrespondenceCreateRoute from './CorrespondenceCreateRoute';
 import { translationsProperties } from '../../../test/helpers';

--- a/src/routes/CorrespondenceEditRoute/CorrespondenceEditRoute.test.js
+++ b/src/routes/CorrespondenceEditRoute/CorrespondenceEditRoute.test.js
@@ -1,5 +1,5 @@
 
-import { renderWithIntl } from '@folio/stripes-erm-components';
+import { renderWithIntl } from '@folio/stripes-erm-testing';
 
 import CorrespondenceEditRoute from './CorrespondenceEditRoute';
 import { translationsProperties } from '../../../test/helpers';

--- a/src/routes/CorrespondenceEditRoute/CorrespondenceEditRoute.test.js
+++ b/src/routes/CorrespondenceEditRoute/CorrespondenceEditRoute.test.js
@@ -1,4 +1,4 @@
-import '@folio/stripes-erm-components/test/jest/__mock__';
+
 import { renderWithIntl } from '@folio/stripes-erm-components';
 
 import CorrespondenceEditRoute from './CorrespondenceEditRoute';

--- a/src/routes/CorrespondenceViewRoute/CorrespondenceViewRoute.test.js
+++ b/src/routes/CorrespondenceViewRoute/CorrespondenceViewRoute.test.js
@@ -1,4 +1,4 @@
-import '@folio/stripes-erm-components/test/jest/__mock__';
+
 import { renderWithIntl } from '@folio/stripes-erm-components';
 
 import CorrespondenceViewRoute from './CorrespondenceViewRoute';

--- a/src/routes/CorrespondenceViewRoute/CorrespondenceViewRoute.test.js
+++ b/src/routes/CorrespondenceViewRoute/CorrespondenceViewRoute.test.js
@@ -1,5 +1,5 @@
 
-import { renderWithIntl } from '@folio/stripes-erm-components';
+import { renderWithIntl } from '@folio/stripes-erm-testing';
 
 import CorrespondenceViewRoute from './CorrespondenceViewRoute';
 import { translationsProperties } from '../../../test/helpers';

--- a/src/routes/JournalEditRoute/JournalEditRoute.test.js
+++ b/src/routes/JournalEditRoute/JournalEditRoute.test.js
@@ -1,5 +1,5 @@
 
-import { renderWithIntl } from '@folio/stripes-erm-components';
+import { renderWithIntl } from '@folio/stripes-erm-testing';
 
 import JournalEditRoute from './JournalEditRoute';
 import { translationsProperties } from '../../../test/helpers';

--- a/src/routes/JournalEditRoute/JournalEditRoute.test.js
+++ b/src/routes/JournalEditRoute/JournalEditRoute.test.js
@@ -1,4 +1,4 @@
-import '@folio/stripes-erm-components/test/jest/__mock__';
+
 import { renderWithIntl } from '@folio/stripes-erm-components';
 
 import JournalEditRoute from './JournalEditRoute';

--- a/src/routes/LinkInvoiceRoute/LinkInvoiceRoute.test.js
+++ b/src/routes/LinkInvoiceRoute/LinkInvoiceRoute.test.js
@@ -1,4 +1,4 @@
-import '@folio/stripes-erm-components/test/jest/__mock__';
+
 import { renderWithIntl } from '@folio/stripes-erm-components';
 
 import LinkInvoiceRoute from './LinkInvoiceRoute';

--- a/src/routes/LinkInvoiceRoute/LinkInvoiceRoute.test.js
+++ b/src/routes/LinkInvoiceRoute/LinkInvoiceRoute.test.js
@@ -1,5 +1,5 @@
 
-import { renderWithIntl } from '@folio/stripes-erm-components';
+import { renderWithIntl } from '@folio/stripes-erm-testing';
 
 import LinkInvoiceRoute from './LinkInvoiceRoute';
 import { translationsProperties } from '../../../test/helpers';

--- a/src/routes/PartyCreateRoute/PartyCreateRoute.test.js
+++ b/src/routes/PartyCreateRoute/PartyCreateRoute.test.js
@@ -1,4 +1,4 @@
-import '@folio/stripes-erm-components/test/jest/__mock__';
+
 import { renderWithIntl } from '@folio/stripes-erm-components';
 
 import PartyCreateRoute from './PartyCreateRoute';

--- a/src/routes/PartyCreateRoute/PartyCreateRoute.test.js
+++ b/src/routes/PartyCreateRoute/PartyCreateRoute.test.js
@@ -1,5 +1,5 @@
 
-import { renderWithIntl } from '@folio/stripes-erm-components';
+import { renderWithIntl } from '@folio/stripes-erm-testing';
 
 import PartyCreateRoute from './PartyCreateRoute';
 import { translationsProperties } from '../../../test/helpers';

--- a/src/routes/PartyEditRoute/PartyEditRoute.test.js
+++ b/src/routes/PartyEditRoute/PartyEditRoute.test.js
@@ -1,4 +1,4 @@
-import '@folio/stripes-erm-components/test/jest/__mock__';
+
 import { renderWithIntl } from '@folio/stripes-erm-components';
 
 import PartyEditRoute from './PartyEditRoute';

--- a/src/routes/PartyEditRoute/PartyEditRoute.test.js
+++ b/src/routes/PartyEditRoute/PartyEditRoute.test.js
@@ -1,5 +1,5 @@
 
-import { renderWithIntl } from '@folio/stripes-erm-components';
+import { renderWithIntl } from '@folio/stripes-erm-testing';
 
 import PartyEditRoute from './PartyEditRoute';
 import { translationsProperties } from '../../../test/helpers';

--- a/src/routes/PublicationRequestCreateRoute/PublicationRequestCreateRoute.test.js
+++ b/src/routes/PublicationRequestCreateRoute/PublicationRequestCreateRoute.test.js
@@ -1,4 +1,4 @@
-import '@folio/stripes-erm-components/test/jest/__mock__';
+
 import { renderWithIntl } from '@folio/stripes-erm-components';
 
 import PublicationRequestCreateRoute from './PublicationRequestCreateRoute';

--- a/src/routes/PublicationRequestCreateRoute/PublicationRequestCreateRoute.test.js
+++ b/src/routes/PublicationRequestCreateRoute/PublicationRequestCreateRoute.test.js
@@ -1,5 +1,5 @@
 
-import { renderWithIntl } from '@folio/stripes-erm-components';
+import { renderWithIntl } from '@folio/stripes-erm-testing';
 
 import PublicationRequestCreateRoute from './PublicationRequestCreateRoute';
 import { translationsProperties } from '../../../test/helpers';

--- a/src/routes/PublicationRequestEditRoute/PublicationRequestEditRoute.test.js
+++ b/src/routes/PublicationRequestEditRoute/PublicationRequestEditRoute.test.js
@@ -1,4 +1,4 @@
-import '@folio/stripes-erm-components/test/jest/__mock__';
+
 import { renderWithIntl } from '@folio/stripes-erm-components';
 
 import PublicationRequestEditRoute from './PublicationRequestEditRoute';

--- a/src/routes/PublicationRequestEditRoute/PublicationRequestEditRoute.test.js
+++ b/src/routes/PublicationRequestEditRoute/PublicationRequestEditRoute.test.js
@@ -1,5 +1,5 @@
 
-import { renderWithIntl } from '@folio/stripes-erm-components';
+import { renderWithIntl } from '@folio/stripes-erm-testing';
 
 import PublicationRequestEditRoute from './PublicationRequestEditRoute';
 import { translationsProperties } from '../../../test/helpers';

--- a/test/helpers/translationsProperties.js
+++ b/test/helpers/translationsProperties.js
@@ -1,5 +1,6 @@
-import translations from '../../translations/ui-oa/en';
 import { translationsProperties as coreTranslations } from '@folio/stripes-erm-testing';
+
+import translations from '../../translations/ui-oa/en';
 
 const translationsProperties = [
   {

--- a/test/helpers/translationsProperties.js
+++ b/test/helpers/translationsProperties.js
@@ -1,33 +1,12 @@
 import translations from '../../translations/ui-oa/en';
+import { translationsProperties as coreTranslations } from '@folio/stripes-erm-testing';
 
 const translationsProperties = [
   {
     prefix: 'ui-oa',
     translations,
   },
-  {
-    prefix: 'stripes-core',
-    translations: {
-      'label.missingRequiredField': 'Please fill this in to continue',
-      'button.save': 'Save',
-    }
-  },
-  {
-    prefix: 'stripes-components',
-    translations: {
-      'saveAndClose': 'Save and close',
-      'cancel': 'Cancel',
-      'paneMenuActionsToggleLabel': 'Actions',
-      'noValue.noValueSet': 'No value set',
-      'collapseAll': 'Collapse all',
-      'button.edit': 'Edit',
-      'tableEmpty': 'The list contains no items',
-      'metaSection.recordCreated': 'Record created: {date} {time}',
-      'metaSection.recordCreatedNoData': 'Record created: Unknown',
-      'metaSection.recordLastUpdated': 'Record last updated: {date} {time}',
-      'metaSection.recordLastUpdatedNoData': 'Record last updated: Unknown',
-    },
-  }
+  ...coreTranslations
 ];
 
 export default translationsProperties;


### PR DESCRIPTION
Move over to new testing repository

Once stripes-erm-components v8 is released, all test stuff will be removed, instead it will all be in stripes-erm-testing.
This includes the direct mock imports in each test file.

This PR however includes work to set up jest manual mocking, so the import line mentioned above should be removable entirely, instead relying on the manual mocks to pick up the slack (And making them adaptable in individual tests where necessary)