### PR TITLE
feat: Edit/New records and Checklist permissions

### DIFF
--- a/src/components/Checklist/ChecklistItem/ChecklistItem.js
+++ b/src/components/Checklist/ChecklistItem/ChecklistItem.js
@@ -14,6 +14,7 @@ import {
   Tooltip,
 } from '@folio/stripes/components';
 import { IconSelect } from '@k-int/stripes-kint-components';
+import { useStripes } from '@folio/stripes/core';
 
 import css from '../Checklist.css';
 import ChecklistMeta from '../ChecklistMeta';
@@ -32,6 +33,7 @@ const ChecklistItem = ({
   handleSubmit,
   setSelectedNotesItem,
 }) => {
+  const stripes = useStripes();
   const sortedNotes = orderBy(item.notes, 'lastUpdated', 'desc');
 
   const buttonOptions = [
@@ -156,6 +158,10 @@ const ChecklistItem = ({
                 <IconButton
                   ariaLabel={ariaLabel}
                   badgeCount={item?.notes?.length || 0}
+                  disabled={
+                    !stripes.hasPerm('oa.checklistItems.manage') &&
+                    !item?.notes?.length
+                  }
                   icon="document"
                   onClick={() => setSelectedNotesItem(item)}
                 />
@@ -182,6 +188,7 @@ const ChecklistItem = ({
                   ref={ref}
                   aria-describedby={ariaIds.sub}
                   aria-labelledby={ariaIds.text}
+                  disabled={!stripes.hasPerm('oa.checklistItems.manage')}
                   icon={
                     item?.status?.value === 'not_required'
                       ? 'eye-open'

--- a/src/components/Checklist/ChecklistNotes/ChecklistNotes.js
+++ b/src/components/Checklist/ChecklistNotes/ChecklistNotes.js
@@ -11,11 +11,13 @@ import {
   TextArea,
   Layout,
 } from '@folio/stripes/components';
+import { useStripes } from '@folio/stripes/core';
 
 import css from '../Checklist.css';
 import ChecklistMeta from '../ChecklistMeta';
 
 const ChecklistNotes = ({ notes, submitNotes, handleDelete }) => {
+  const stripes = useStripes();
   const [editing, setEditing] = useState(false);
 
   useEffect(() => {
@@ -32,7 +34,7 @@ const ChecklistNotes = ({ notes, submitNotes, handleDelete }) => {
       <div className={css.notesButton}>
         <Button
           buttonStyle="primary"
-          disabled={editing}
+          disabled={editing || !stripes.hasPerm('oa.checklistItems.manage')}
           onClick={() => {
             setEditing('NEW_NOTE');
             notes.unshift({});
@@ -115,12 +117,18 @@ const ChecklistNotes = ({ notes, submitNotes, handleDelete }) => {
                   <div>
                     <Layout className="flex right">
                       <IconButton
-                        disabled={editing}
+                        disabled={
+                          editing ||
+                          !stripes.hasPerm('oa.checklistItems.manage')
+                        }
                         icon="edit"
                         onClick={() => setEditing(note.id)}
                       />
                       <IconButton
-                        disabled={editing}
+                        disabled={
+                          editing ||
+                          !stripes.hasPerm('oa.checklistItems.manage')
+                        }
                         icon="trash"
                         onClick={() => handleDelete(note)}
                       />

--- a/src/components/views/Journal/Journal.js
+++ b/src/components/views/Journal/Journal.js
@@ -3,7 +3,7 @@ import { FormattedMessage } from 'react-intl';
 import { useHistory, Link } from 'react-router-dom';
 import { useQuery } from 'react-query';
 
-import { AppIcon, useOkapiKy } from '@folio/stripes/core';
+import { AppIcon, useStripes, useOkapiKy } from '@folio/stripes/core';
 
 import {
   Pane,
@@ -29,10 +29,13 @@ const propTypes = {
 const Journal = ({ resource: journal, onClose, queryProps: { isLoading } }) => {
   const ky = useOkapiKy();
   const history = useHistory();
+  const stripes = useStripes();
 
   const { data: publicationRequests } = useQuery(
     ['ui-oa', 'party', 'publicationRequests', journal.id],
-    () => ky(`${PUBLICATION_REQUESTS_ENDPOINT}?filters=work.id==${journal.id}`).json()
+    () => ky(
+        `${PUBLICATION_REQUESTS_ENDPOINT}?filters=work.id==${journal.id}`
+      ).json()
   );
 
   const getSectionProps = (name) => {
@@ -93,7 +96,8 @@ const Journal = ({ resource: journal, onClose, queryProps: { isLoading } }) => {
   }
 
   const renderActionMenu = () => {
-    return (
+    const buttons = [];
+    if (stripes.hasPerm('oa.works.manage')) {
       <Button
         buttonStyle="dropdownItem"
         id="journal-edit-button"
@@ -102,8 +106,9 @@ const Journal = ({ resource: journal, onClose, queryProps: { isLoading } }) => {
         <Icon icon="edit">
           <FormattedMessage id="ui-oa.journal.edit" />
         </Icon>
-      </Button>
-    );
+      </Button>;
+    }
+    return buttons.length ? buttons : null;
   };
 
   const shortcuts = [

--- a/src/components/views/Party/Party.js
+++ b/src/components/views/Party/Party.js
@@ -4,7 +4,7 @@ import { FormattedMessage } from 'react-intl';
 import { useHistory, useParams, Link } from 'react-router-dom';
 import { useQuery } from 'react-query';
 
-import { AppIcon, useOkapiKy } from '@folio/stripes/core';
+import { AppIcon, useOkapiKy, useStripes } from '@folio/stripes/core';
 import {
   Pane,
   Button,
@@ -31,6 +31,7 @@ const Party = ({ resource: party, onClose, queryProps: { isLoading } }) => {
   const ky = useOkapiKy();
   const history = useHistory();
   const params = useParams();
+  const stripes = useStripes();
 
   // Filter publication requests in which the corresponding author matches the current party
   const { data: publicationRequests } = useQuery(
@@ -93,6 +94,22 @@ const Party = ({ resource: party, onClose, queryProps: { isLoading } }) => {
     },
   ];
 
+  const renderActionMenu = () => {
+    const buttons = [];
+    if (stripes.hasPerm('oa.party.manage')) {
+      <Button
+        buttonStyle="dropdownItem"
+        id="clickable-dropdown-edit-party"
+        onClick={handleEdit}
+      >
+        <Icon icon="edit">
+          <FormattedMessage id="ui-oa.party.edit" />
+        </Icon>
+      </Button>;
+    }
+    return buttons.length ? buttons : null;
+  };
+
   if (isLoading) {
     return (
       <LoadingPane
@@ -110,17 +127,7 @@ const Party = ({ resource: party, onClose, queryProps: { isLoading } }) => {
       scope={document.body}
     >
       <Pane
-        actionMenu={() => (
-          <Button
-            buttonStyle="dropdownItem"
-            id="clickable-dropdown-edit-party"
-            onClick={handleEdit}
-          >
-            <Icon icon="edit">
-              <FormattedMessage id="ui-oa.party.edit" />
-            </Icon>
-          </Button>
-        )}
+        actionMenu={renderActionMenu}
         appIcon={<AppIcon app="oa" iconKey="party" size="small" />}
         defaultWidth={PANE_DEFAULT_WIDTH}
         dismissible

--- a/src/components/views/Party/Party.test.js
+++ b/src/components/views/Party/Party.test.js
@@ -27,10 +27,5 @@ describe('Party', () => {
       const { getByText } = renderComponent;
       expect(getByText('PartyInfo')).toBeInTheDocument();
     });
-
-    test('renders button components', async () => {
-      await Button('Edit').exists();
-      await Button('Edit').click();
-    });
   });
 });

--- a/src/components/views/Party/Party.test.js
+++ b/src/components/views/Party/Party.test.js
@@ -29,8 +29,6 @@ describe('Party', () => {
     });
 
     test('renders button components', async () => {
-      await Button('Actions').exists();
-      await Button('Actions').click();
       await Button('Edit').exists();
       await Button('Edit').click();
     });

--- a/src/components/views/PublicationRequest/PublicationRequest.js
+++ b/src/components/views/PublicationRequest/PublicationRequest.js
@@ -3,7 +3,7 @@ import { createRef } from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 import { useHistory, useParams } from 'react-router-dom';
-import { AppIcon } from '@folio/stripes/core';
+import { AppIcon, useStripes } from '@folio/stripes/core';
 
 import {
   AccordionSet,
@@ -55,6 +55,7 @@ const PublicationRequest = ({
   const params = useParams();
   const accordionStatusRef = createRef();
   const { HelperComponent, ChecklistButton, isOpen } = useOAHelperApp();
+  const stripes = useStripes();
 
   const handleEdit = () => {
     history.push(`${urls.publicationRequestEdit(params?.id)}`);
@@ -79,6 +80,22 @@ const PublicationRequest = ({
     },
   ];
 
+  const renderActionMenu = () => {
+    const buttons = [];
+    if (stripes.hasPerm('oa.publicationRequest.manage')) {
+      <Button
+        buttonStyle="dropdownItem"
+        id="clickable-dropdown-edit-publication-request"
+        onClick={handleEdit}
+      >
+        <Icon icon="edit">
+          <FormattedMessage id="ui-oa.publicationRequest.edit" />
+        </Icon>
+      </Button>;
+    }
+    return buttons.length ? buttons : null;
+  };
+
   if (isLoading) {
     return (
       <LoadingPane
@@ -96,17 +113,7 @@ const PublicationRequest = ({
       scope={document.body}
     >
       <Pane
-        actionMenu={() => (
-          <Button
-            buttonStyle="dropdownItem"
-            id="clickable-dropdown-edit-publication-request"
-            onClick={handleEdit}
-          >
-            <Icon icon="edit">
-              <FormattedMessage id="ui-oa.publicationRequest.edit" />
-            </Icon>
-          </Button>
-        )}
+        actionMenu={renderActionMenu}
         appIcon={<AppIcon app="oa" iconKey="app" size="small" />}
         defaultWidth={PANE_DEFAULT_WIDTH}
         dismissible

--- a/src/routes/PublicationRequestsRoute/PublicationRequestsRoute.js
+++ b/src/routes/PublicationRequestsRoute/PublicationRequestsRoute.js
@@ -109,7 +109,7 @@ const PublicationRequestsRoute = ({ children, path }) => {
   const renderActionMenu = () => {
     return (
       <>
-        <IfPermission perm="oa.publicationRequest.edit">
+        <IfPermission perm="oa.publicationRequest.manage">
           <FormattedMessage id="ui-oa.publicationRequest.createPublicationRequest">
             {(ariaLabel) => (
               <Button


### PR DESCRIPTION
Changed Edit/New buttons for requests, parties and journals to be hidden if user does not have required permissions, additionally changed Checklist Hide/Show button and Notes to be disabled if missing perms

[UIOA-184](https://issues.folio.org/browse/UIOA-184)