### PR TITLE
chore: Bumped to stripes-kint-components ^4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,8 +38,7 @@
       "finance.exchange-rate": "1.0"
     },
     "stripesDeps": [
-      "@folio/stripes-erm-components",
-      "@k-int/stripes-kint-components"
+      "@folio/stripes-erm-components"
     ],
     "icons": [
       {
@@ -177,7 +176,7 @@
   },
   "dependencies": {
     "@folio/stripes-acq-components": "^3.1.0",
-    "@k-int/stripes-kint-components": "^3.1.0",
+    "@k-int/stripes-kint-components": "^4.0.0",
     "classnames": "^2.2.6",
     "compose-function": "^3.0.3",
     "final-form": "^4.18.5",


### PR DESCRIPTION
kint-components 4.0.0 introduces a breaking change, encodeURI should no longer be performed on the output of generateKiwtQueryParams unless `encode` is set to false