### PR TITLE
fix: Checklist item outcome permission

### DIFF
--- a/src/components/Checklist/ChecklistItem/ChecklistItem.js
+++ b/src/components/Checklist/ChecklistItem/ChecklistItem.js
@@ -105,6 +105,7 @@ const ChecklistItem = ({
             {([ariaLabel]) => (
               <IconSelect
                 ariaLabel={ariaLabel}
+                disabled={!stripes.hasPerm('oa.checklistItems.manage')}
                 id={`${item?.definition?.name}-icon-select`}
                 input={{
                   name: 'outcome',


### PR DESCRIPTION
Added disabled prop to checklist item icon select for outcome which disables the button when the user is missing required permissions

[UIOA-184](https://issues.folio.org/browse/UIOA-184)