### PR TITLE
chore: Stripes-erm-components

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
     "@babel/preset-typescript": "^7.18.6",
     "@folio/eslint-config-stripes": "^6.1.0",
     "@folio/handler-stripes-registry": "^1.1.1",
-    "@folio/stripes-erm-components": "^7.0.0",
+    "@folio/stripes-erm-components": "^8.0.0",
     "@folio/stripes-erm-testing": "^1.0.0",
     "@folio/service-interaction": "^1.0.0",
     "@folio/stripes": "^7.2.0",
@@ -190,7 +190,7 @@
   },
   "peerDependencies": {
     "@folio/handler-stripes-registry": "^1.1.1",
-    "@folio/stripes-erm-components": "^7.0.0",
+    "@folio/stripes-erm-components": "^8.0.0",
     "@folio/service-interaction": "^1.0.0",
     "@folio/stripes": "^7.0.0",
     "moment": "^2.22.2",


### PR DESCRIPTION
Bumped major version of stripes-erm-components to ^8.0.0, reflecting removal of testing stuff for Orchid