### PR TITLE
feat: Reapply checklist filters button

### DIFF
--- a/src/components/SearchAndFilter/ChecklistFilter/ChecklistFilter.js
+++ b/src/components/SearchAndFilter/ChecklistFilter/ChecklistFilter.js
@@ -3,19 +3,21 @@ import { useState } from 'react';
 import {
   Accordion,
   FilterAccordionHeader,
+  IconButton,
   Layout,
 } from '@folio/stripes/components';
 import { FormattedMessage } from 'react-intl';
+import { useQueryClient } from 'react-query';
 import useChecklistItemDefinitions from '../../../hooks/useChecklistItemDefinitions';
 
 import ChecklistFilterForm from './ChecklistFilterForm';
 
 const ChecklistFilter = ({ activeFilters, filterHandlers }) => {
+  const queryClient = useQueryClient();
   const checklistItems = useChecklistItemDefinitions();
   const [editingFilters, setEditingFilters] = useState(false);
   const openEditModal = () => setEditingFilters(true);
   const closeEditModal = () => setEditingFilters(false);
-
   // Example query for searching if an outcome != no, not set or if the checklist item hasnt been touched
   // (checklist.definition.name==test&&checklist.outcome isNull)||(checklist.definition.name==test&&checklist.outcome.value!=no)||!(checklist.definition.name==test)
 
@@ -108,9 +110,37 @@ const ChecklistFilter = ({ activeFilters, filterHandlers }) => {
     setEditingFilters(false);
   };
 
+  const renderRefreshButton = () => {
+    return (
+      <>
+        {!!parsedFilterData.length && (
+          <FormattedMessage id="ui-oa.checklistFilter.reapplyFilters">
+            {(ariaLabel) => (
+              <IconButton
+                ariaLabel={ariaLabel}
+                icon="refresh"
+                iconSize="small"
+                onClick={() => queryClient.invalidateQueries([
+                    '@folio/oa',
+                    'SASQ',
+                    'publication-requests',
+                    'viewAll',
+                  ])
+                }
+                size="small"
+              />
+            )}
+          </FormattedMessage>
+        )}
+      </>
+    );
+  };
+
   return (
     <Accordion
       displayClearButton={parsedFilterData?.length}
+      displayWhenClosed={renderRefreshButton()}
+      displayWhenOpen={renderRefreshButton()}
       header={FilterAccordionHeader}
       id="clickable-checklist-filter"
       label={<FormattedMessage id="ui-oa.checklistFilter.checklistItems" />}

--- a/translations/ui-oa/en.json
+++ b/translations/ui-oa/en.json
@@ -89,6 +89,7 @@
   "checklistFilter.attribute.outcome": "Outcome",
   "checklistFilter.attribute.visibility": "Visibility",
   "checklistFilter.value.notSet": "Not set",
+  "checklistFilter.reapplyFilters": "Reapply filters",
 
 
   "parties.people": "People",


### PR DESCRIPTION
Added button to checklist filters accordion header to allow for re-application of filters upon changing of a checklist item

[UIOA-198](https://issues.folio.org/browse/UIOA-198)