### PR TITLE
fix: Email fields max length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## 2.0.0 In progress
 * Upgrade `stripes-acq-components` to `v4` and remove unneeded `react-redux`. Refs UIOA-204.
 * Added enabled option to invoice hooks to prevent fetches with undefined values
+* Updated max length props for mainEmail and alternateEmails from 36 characters to 255 to reflect database data type
+
 
 ## 1.0.0 2023-01-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 2.0.0 In progress
 * Upgrade `stripes-acq-components` to `v4` and remove unneeded `react-redux`. Refs UIOA-204.
 * Added enabled option to invoice hooks to prevent fetches with undefined values
-* Updated max length props for mainEmail and alternateEmails from 36 characters to 255 to reflect database data type
+* Updated max length props for mainEmail and alternateEmails from 36 characters to 255 to reflect database data type. Refs UIOA-205/206
 
 
 ## 1.0.0 2023-01-10

--- a/src/components/PartyFormSections/OtherEmailsFieldArray/OtherEmailsFieldArray.js
+++ b/src/components/PartyFormSections/OtherEmailsFieldArray/OtherEmailsFieldArray.js
@@ -14,7 +14,7 @@ import {
 } from '@folio/stripes/components';
 import { requiredValidator } from '@folio/stripes-erm-components';
 import { useKiwtFieldArray } from '@k-int/stripes-kint-components';
-import { MAX_CHAR_SHORT } from '../../../constants/config';
+import { MAX_CHAR_LONG } from '../../../constants/config';
 
 const OtherEmailsField = ({ fields: { name } }) => {
   const { items, onAddField, onDeleteField } = useKiwtFieldArray(name);
@@ -28,11 +28,11 @@ const OtherEmailsField = ({ fields: { name } }) => {
       {items.map((email, index) => {
         return (
           <Row key={email}>
-            <Col xs={9}>
+            <Col xs={3}>
               <Field
                 component={TextField}
                 label={<FormattedMessage id="ui-oa.party.emailAddress" />}
-                maxLength={MAX_CHAR_SHORT}
+                maxLength={MAX_CHAR_LONG}
                 name={`${name}[${index}].email`}
                 required
                 validate={requiredValidator}

--- a/src/components/PartyFormSections/PartyInfoForm/PartyInfoForm.js
+++ b/src/components/PartyFormSections/PartyInfoForm/PartyInfoForm.js
@@ -3,7 +3,7 @@ import { Field } from 'react-final-form';
 
 import { Col, Row, TextField } from '@folio/stripes/components';
 import { requiredValidator } from '@folio/stripes-erm-components';
-import { MAX_CHAR_SHORT } from '../../../constants/config';
+import { MAX_CHAR_LONG, MAX_CHAR_SHORT } from '../../../constants/config';
 
 const PartyInfoForm = () => {
   return (
@@ -55,7 +55,7 @@ const PartyInfoForm = () => {
           <Field
             component={TextField}
             label={<FormattedMessage id="ui-oa.party.mainEmailAddress" />}
-            maxLength={MAX_CHAR_SHORT}
+            maxLength={MAX_CHAR_LONG}
             name="mainEmail"
             parse={(v) => v}
           />


### PR DESCRIPTION
Updated max length props for mainEmail and alternateEmails from 36 characters to 255 to reflect data type

[UIOA-205](https://issues.folio.org/browse/UIOA-205), [UIOA-206](https://issues.folio.org/browse/UIOA-206)