### PR TITLE
fix: Publication title field max length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Added ability for journal typedown to be searched by matching ISSNs. Refs UIOA-210.
 * Upgraded 'stripes-kint-components' to 'v 4.4.0' 
 * Removed validateNoSpecialCharacters validation from checklist item definition label field. Refs UIOA-211
+* Changed publication title fields max length to 4096. Refs UIOA-212
 
 
 ## 1.0.0 2023-01-10

--- a/src/components/PublicationRequestFormSections/PublicationForm/PublicationForm/PublicationForm.js
+++ b/src/components/PublicationRequestFormSections/PublicationForm/PublicationForm/PublicationForm.js
@@ -120,7 +120,7 @@ const PublicationForm = () => {
             label={
               <FormattedMessage id="ui-oa.publicationRequest.publicationTitle" />
             }
-            maxLength={MAX_CHAR_LONG}
+            maxLength={4096}
             name="publicationTitle"
             parse={(v) => v}
           />


### PR DESCRIPTION
Modified publication title fields maxLength prop to 4096 to be able to accommodate longer titles

[UIOA-212](https://issues.folio.org/browse/UIOA-212)