### PR TITLE
Adjust path to interaction styles

### DIFF
--- a/src/components/Checklist/HiddenHeader/HiddenHeader.css
+++ b/src/components/Checklist/HiddenHeader/HiddenHeader.css
@@ -67,7 +67,7 @@
 }
 
 .defaultCollapseButton {
-  composes: interactionStylesControl from '@folio/stripes-components/lib/sharedStyles/interactionStyles.css';
+  composes: interactionStylesControl from '~@folio/stripes-components/lib/sharedStyles/interactionStyles.css';
   flex: 1;
   border: none;
   outline: none;
@@ -91,7 +91,7 @@
 }
 
 .headerInner {
-  composes: interactionStyles boxOffsetStartMedium boxOffsetEndMedium from '@folio/stripes-components/lib/sharedStyles/interactionStyles.css';
+  composes: interactionStyles boxOffsetStartMedium boxOffsetEndMedium from '~@folio/stripes-components/lib/sharedStyles/interactionStyles.css';
   width: 100%;
   display: flex;
   align-items: center;


### PR DESCRIPTION
Hey @Jack-Golding, I ran into this issue while working on stripes transpilation:

````css
/ui-oa/src/components/Checklist/HiddenHeader/HiddenHeader.css
Module build failed (from ./node_modules/mini-css-extract-plugin/dist/loader.js):
ModuleNotFoundError: Module not found: Error: Can't resolve './@folio/stripes-components/lib/sharedStyles/interactionStyles.css' in '/projects/folio/transpilation/ui-oa/src/components/Checklist/HiddenHeader'
    at /projects/folio/transpilation/node_modules/webpack/lib/Compilation.js:2016:28
    at /projects/folio/transpilation/node_modules/webpack/lib/NormalModuleFactory.js:798:13
    at eval (eval at create (/projects/folio/transpilation/node_modules/webpack/node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:10:1)
    at /projects/folio/transpilation/node_modules/webpack/lib/NormalModuleFactory.js:270:22
    at eval (eval at create (/projects/folio/transpilation/node_modules/webpack/node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:9:1)
    at /projects/folio/transpilation/node_modules/webpack/lib/NormalModuleFactory.js:434:22
    at /projects/folio/transpilation/node_modules/webpack/lib/NormalModuleFactory.js:116:11
    at /projects/folio/transpilation/node_modules/webpack/lib/NormalModuleFactory.js:670:25
    at /projects/folio/transpilation/node_modules/webpack/lib/NormalModuleFactory.js:855:8
    at /projects/folio/transpilation/node_modules/webpack/lib/NormalModuleFactory.js:975:5
    at /projects/folio/transpilation/node_modules/neo-async/async.js:6883:13
    at Array.<anonymous> (/projects/folio/transpilation/node_modules/webpack/lib/NormalModuleFactory.js:950:14)
    at arrayEachFunc (/projects/folio/transpilation/node_modules/neo-async/async.js:2517:19)
    at Object.parallel (/projects/folio/transpilation/node_modules/neo-async/async.js:6858:9)
    at NormalModuleFactory._resolveResourceErrorHints (/projects/folio/transpilation/node_modules/webpack/lib/NormalModuleFactory.js:873:12)
    at /projects/folio/transpilation/node_modules/webpack/lib/NormalModuleFactory.js:834:18
    at finishWithoutResolve (/projects/folio/transpilation/node_modules/enhanced-resolve/lib/Resolver.js:312:11)
    at /projects/folio/transpilation/node_modules/enhanced-resolve/lib/Resolver.js:386:15
    at /projects/folio/transpilation/node_modules/enhanced-resolve/lib/Resolver.js:435:5
    at eval (eval at create (/projects/folio/transpilation/node_modules/enhanced-resolve/node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:15:1)
    at /projects/folio/transpilation/node_modules/enhanced-resolve/lib/Resolver.js:435:5
    at eval (eval at create (/projects/folio/transpilation/node_modules/enhanced-resolve/node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:27:1)
    at /projects/folio/transpilation/node_modules/enhanced-resolve/lib/DescriptionFilePlugin.js:87:43
    at /projects/folio/transpilation/node_modules/enhanced-resolve/lib/Resolver.js:435:5
    at eval (eval at create (/projects/folio/transpilation/node_modules/enhanced-resolve/node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:15:1)
    at /projects/folio/transpilation/node_modules/enhanced-resolve/lib/Resolver.js:435:5
    at eval (eval at create (/projects/folio/transpilation/node_modules/enhanced-resolve/node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:16:1)
    at /projects/folio/transpilation/node_modules/enhanced-resolve/lib/Resolver.js:435:5
    at eval (eval at create (/projects/folio/transpilation/node_modules/enhanced-resolve/node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:16:1)
    at /projects/folio/transpilation/node_modules/enhanced-resolve/lib/Resolver.js:435:5
    at eval (eval at create (/projects/folio/transpilation/node_modules/enhanced-resolve/node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:27:1)
    at /projects/folio/transpilation/node_modules/enhanced-resolve/lib/DescriptionFilePlugin.js:87:43
    at /projects/folio/transpilation/node_modules/enhanced-resolve/lib/Resolver.js:435:5
    at eval (eval at create (/projects/folio/transpilation/node_modules/enhanced-resolve/node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:16:1)
    at /projects/folio/transpilation/node_modules/enhanced-resolve/lib/Resolver.js:435:5
    at eval (eval at create (/projects/folio/transpilation/node_modules/enhanced-resolve/node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:15:1)
    at /projects/folio/transpilation/node_modules/enhanced-resolve/lib/DirectoryExistsPlugin.js:41:15
    at processTicksAndRejections (node:internal/process/task_queues:82:21)
 @ ./ui-oa/src/components/Checklist/HiddenHeader/HiddenHeader.js 13:0-37 75:17-46 80:15-32 82:27-37 82:51-62 93:21-46 100:23-38 102:25-46 108:25-38
 @ ./ui-oa/src/components/Checklist/Checklist.js 26:0-55 188:14-26
 @ ./ui-oa/src/components/Checklist/index.js 1:0-38 1:0-38
 @ ./ui-oa/src/hooks/useOAHelperApp.js 5:0-48 13:17-26
 @ ./ui-oa/src/components/views/PublicationRequest/PublicationRequest.js 15:0-59 34:24-38
 @ ./ui-oa/src/components/views/PublicationRequest/index.js 1:0-47 1:0-47
 @ ./ui-oa/src/routes/PublicationRequestsRoute/PublicationRequestsRoute.js 15:0-75 203:23-41
 @ ./ui-oa/src/routes/PublicationRequestsRoute/index.js 1:0-53 1:0-53
 @ ./ui-oa/src/routes/index.js 1:0-81 1:0-81
 @ ./ui-oa/src/index.js 21:0-341 78:25-54 81:25-52 84:25-50 87:25-48 90:25-41 93:25-42 96:25-40 99:25-41 102:25-41 105:25-39 107:34-46 109:34-47 111:35-59 114:27-42 117:27-50
 @ ./node_modules/stripes-config.js
````

This PR is trying to address it by prefixing the path to `@folio/stripes-components/lib/sharedStyles/interactionStyles.css` with `~`.
 