### PR TITLE
chore: Bump dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,11 +125,11 @@
     "@babel/preset-flow": "^7.18.6",
     "@babel/preset-typescript": "^7.18.6",
     "@folio/eslint-config-stripes": "^7.0.0",
-    "@folio/handler-stripes-registry": "^1.1.1",
+    "@folio/handler-stripes-registry": "^2.1.0",
     "@folio/jest-config-stripes": "^2.0.0",
     "@folio/stripes-erm-components": "^9.0.0",
     "@folio/stripes-erm-testing": "^2.0.0",
-    "@folio/service-interaction": "^1.0.0",
+    "@folio/service-interaction": "^2.0.0",
     "@folio/stripes": "^9.0.0",
     "@folio/stripes-cli": "^3.0.0",
     "eslint": "^7.32.0",
@@ -148,7 +148,7 @@
     "typescript": "^2.8.0"
   },
   "dependencies": {
-    "@folio/stripes-acq-components": "^4.0.0",
+    "@folio/stripes-acq-components": "^5.0.0",
     "@k-int/stripes-kint-components": "^5.0.0",
     "classnames": "^2.2.6",
     "compose-function": "^3.0.3",
@@ -162,9 +162,9 @@
     "react-final-form-arrays": "^3.1.1"
   },
   "peerDependencies": {
-    "@folio/handler-stripes-registry": "^1.3.0",
+    "@folio/handler-stripes-registry": "^2.1.0",
     "@folio/stripes-erm-components": "^9.0.0",
-    "@folio/service-interaction": "^1.0.0",
+    "@folio/service-interaction": "^2.0.0",
     "@folio/stripes": "^9.0.0",
     "moment": "^2.22.2",
     "react": "^18.2.0",


### PR DESCRIPTION
Updated all dependencies for compatibility with react v18/stripes v9: handler-stripes-registry v2.1.0, service-interaction v2.0.0, stripes-acq-components v5.0.0,

UIOA-220