### PR TITLE
fix: Decimal separator ignored when saving with non-english locale

### DIFF
--- a/src/components/ChargeFormSections/ChargeInfoForm/ChargeInfoForm.js
+++ b/src/components/ChargeFormSections/ChargeInfoForm/ChargeInfoForm.js
@@ -60,7 +60,8 @@ const ChargeInfoForm = () => {
   const statusValues = selectifyRefdata(refdataValues, CHARGE_STATUS);
   const discountTypeValues = selectifyRefdata(
     refdataValues,
-    CHARGE_DISCOUNT_TYPE, 'value'
+    CHARGE_DISCOUNT_TYPE,
+    'value'
   );
 
   const estimatedInvoicePrice = getEstimatedInvoicePrice(values);
@@ -125,6 +126,7 @@ const ChargeInfoForm = () => {
             component={TextField}
             label={<FormattedMessage id="ui-oa.charge.netAmount" />}
             name="amount.value"
+            onChange={(e) => change('amount.value', parseFloat(e?.target?.value))}
             required
             type="number"
             validate={composeValidators(


### PR DESCRIPTION
Fixed issue in which the decimal separator was ignored when saving with non-english locale

[UIOA-222](https://folio-org.atlassian.net/browse/UIOA-222)