### PR TITLE
Granted oa.settings.read on module.oa.enabled

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,8 @@
         "displayName": "UI: ui-oa module is enabled",
         "visible": false,
         "subPermissions": [
-          "oa.refdata.read"
+          "oa.refdata.read",
+          "oa.settings.read"
         ]
       },
       {


### PR DESCRIPTION
Module settings are needed by all users of the OA module so that they can be used in the module. In particular the `default_tax` appSetting is needed when creating charges

By granting `oa.settings.read` as a subpermission of `module.oa.enabled` it ensures that any user of the module can read the settings.