### PR TITLE
UIOA-242: Charge/Correspondence action menu

### DIFF
--- a/src/components/views/ChargeView/ChargeView.js
+++ b/src/components/views/ChargeView/ChargeView.js
@@ -1,7 +1,7 @@
 import { useState, createRef } from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
-import { AppIcon, IfInterface } from '@folio/stripes/core';
+import { AppIcon, IfInterface, useStripes } from '@folio/stripes/core';
 
 import {
   AccordionSet,
@@ -50,6 +50,7 @@ const ChargeView = ({
   const invoice = useInvoice(charge?.invoiceReference);
   const invoiceLine = useInvoiceLine(charge?.invoiceLineItemReference);
   const accordionStatusRef = createRef();
+  const stripes = useStripes();
 
   const shortcuts = [
     {
@@ -67,40 +68,47 @@ const ChargeView = ({
   ];
 
   const renderActionMenu = () => {
-    return (
-      <>
-        <Button
-          buttonStyle="dropdownItem"
-          id="charge-edit-button"
-          onClick={handleEdit}
-        >
-          <Icon icon="edit">
-            <FormattedMessage id="ui-oa.charge.edit" />
-          </Icon>
-        </Button>
-        <IfInterface name="invoice">
-          {!charge?.invoiceReference ? (
-            <Button
-              buttonStyle="dropdownItem"
-              id="link-invoice-button"
-              onClick={handleLink}
-            >
-              <Icon icon="link">
-                <FormattedMessage id="ui-oa.charge.invoice.linkInvoiceLine" />
-              </Icon>
-            </Button>
-          ) : (
-            <Button
-              buttonStyle="dropdownItem"
-              id="unlink-invoice-button"
-              onClick={() => setShowUnlinkConfirmModal(true)}
-            >
-              <Icon icon="unlink">
-                <FormattedMessage id="ui-oa.charge.invoice.unlinkInvoiceLine" />
-              </Icon>
-            </Button>
-          )}
-        </IfInterface>
+    const buttons = [];
+    if (stripes?.hasPerm('ui-oa.charge.edit')) {
+      buttons.push(
+        <>
+          <Button
+            buttonStyle="dropdownItem"
+            id="charge-edit-button"
+            onClick={handleEdit}
+          >
+            <Icon icon="edit">
+              <FormattedMessage id="ui-oa.charge.edit" />
+            </Icon>
+          </Button>
+          <IfInterface name="invoice">
+            {!charge?.invoiceReference ? (
+              <Button
+                buttonStyle="dropdownItem"
+                id="link-invoice-button"
+                onClick={handleLink}
+              >
+                <Icon icon="link">
+                  <FormattedMessage id="ui-oa.charge.invoice.linkInvoiceLine" />
+                </Icon>
+              </Button>
+            ) : (
+              <Button
+                buttonStyle="dropdownItem"
+                id="unlink-invoice-button"
+                onClick={() => setShowUnlinkConfirmModal(true)}
+              >
+                <Icon icon="unlink">
+                  <FormattedMessage id="ui-oa.charge.invoice.unlinkInvoiceLine" />
+                </Icon>
+              </Button>
+            )}
+          </IfInterface>
+        </>
+      );
+    }
+    if (stripes?.hasPerm('ui-oa.charge.manage')) {
+      buttons.push(
         <Button
           buttonStyle="dropdownItem"
           id="charge-delete-button"
@@ -110,8 +118,10 @@ const ChargeView = ({
             <FormattedMessage id="ui-oa.charge.delete" />
           </Icon>
         </Button>
-      </>
-    );
+      );
+    }
+
+    return buttons?.length ? buttons : null;
   };
 
   return (

--- a/src/components/views/CorrespondenceView/CorrespondenceView.js
+++ b/src/components/views/CorrespondenceView/CorrespondenceView.js
@@ -11,7 +11,7 @@ import {
   Icon,
   ConfirmationModal,
 } from '@folio/stripes/components';
-import { AppIcon, IfPermission } from '@folio/stripes/core';
+import { AppIcon, useStripes } from '@folio/stripes/core';
 import { PANE_DEFAULT_WIDTH } from '../../../constants/config';
 
 const propTypes = {
@@ -21,13 +21,9 @@ const propTypes = {
   correspondence: PropTypes.object,
 };
 
-const CorrespondenceView = ({
-  onClose,
-  onDelete,
-  onEdit,
-  correspondence,
-}) => {
+const CorrespondenceView = ({ onClose, onDelete, onEdit, correspondence }) => {
   const [showConfirmationModal, setShowConfirmationModal] = useState(false);
+  const stripes = useStripes();
 
   const openDeleteConfirmationModal = () => {
     setShowConfirmationModal(true);
@@ -38,32 +34,34 @@ const CorrespondenceView = ({
   };
 
   const getActionMenu = () => {
-    return (
-      <>
-        <IfPermission perm="ui-oa.publicationRequest.edit">
-          <Button
-            buttonStyle="dropdownItem"
-            id="correspondence-edit-button"
-            onClick={onEdit}
-          >
-            <Icon icon="edit">
-              <FormattedMessage id="ui-oa.correspondence.edit" />
-            </Icon>
-          </Button>
-        </IfPermission>
-        <IfPermission perm="ui-oa.publicationRequest.edit">
-          <Button
-            buttonStyle="dropdownItem"
-            id="correspondence-delete-button"
-            onClick={openDeleteConfirmationModal}
-          >
-            <Icon icon="trash">
-              <FormattedMessage id="ui-oa.correspondence.delete" />
-            </Icon>
-          </Button>
-        </IfPermission>
-      </>
-    );
+    const buttons = [];
+    if (stripes?.hasPerm('ui-oa.publicationRequest.edit')) {
+      buttons.push(
+        <Button
+          buttonStyle="dropdownItem"
+          id="correspondence-edit-button"
+          onClick={onEdit}
+        >
+          <Icon icon="edit">
+            <FormattedMessage id="ui-oa.correspondence.edit" />
+          </Icon>
+        </Button>
+      );
+    }
+    if (stripes?.hasPerm('ui-oa.publicationRequest.manage')) {
+      buttons.push(
+        <Button
+          buttonStyle="dropdownItem"
+          id="correspondence-delete-button"
+          onClick={openDeleteConfirmationModal}
+        >
+          <Icon icon="trash">
+            <FormattedMessage id="ui-oa.correspondence.delete" />
+          </Icon>
+        </Button>
+      );
+    }
+    return buttons?.length ? buttons : null;
   };
 
   return (


### PR DESCRIPTION
Updated required permissions for charge/correspondence action menu options, fixed issue in which action menu would still display if available options < 1